### PR TITLE
Added option to use branch alias version for dev branches.

### DIFF
--- a/src/Composer/ComposerLockReader.php
+++ b/src/Composer/ComposerLockReader.php
@@ -47,6 +47,14 @@ class ComposerLockReader implements ComposerLockReaderInterface
             [$org, $module] = explode('/', $packageData['name']);
             $packageName = $dashToCamelCaseFilter->filter($org, '-', true) . '.' . $dashToCamelCaseFilter->filter($module, '-', true);
             $packages[$packageName] = $packageData['version'];
+
+            if (strpos($packageData['version'], 'dev-') !== false) {
+                $versionFromExtra = $packageData['extra']['branch-alias']['dev-master'] ?? false;
+                if ($versionFromExtra) {
+                    $aliasedVersion = str_replace('x-dev', '0', $versionFromExtra);
+                    $packages[$packageName] = $aliasedVersion;
+                }
+            }
         }
 
         return $packages;


### PR DESCRIPTION
Added option to use branch alias version for dev branches. 

Currently, the tool would add the branch name as version but this can't be used to create a manifest file for it. When there is a branch name used and we are able to compute the version number out of the branch alias we use that as a version now.