### PR TITLE
Move generation from release app into integrator.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "composer-plugin-api": "^1.0.0 || ^2.0.0",
         "composer/composer": "^2.1.0",
         "laminas/laminas-filter": "^2.11.0",
+        "league/csv": "^9.0",
         "nikic/php-parser": "^4.3.0",
         "sebastian/diff": "^4.0.0",
         "symfony/console": "^5.3.0",

--- a/src/ManifestGenerator/AbstractManifestStrategy.php
+++ b/src/ManifestGenerator/AbstractManifestStrategy.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator;
+
+use SprykerSdk\Integrator\ManifestGenerator\Exception\SyntaxTreeException;
+use SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ExtractedValueObject;
+use SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ValueExtractorStrategyCollection;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+
+abstract class AbstractManifestStrategy
+{
+    /**
+     * @var string
+     */
+    protected const TARGET = 'target';
+
+    /**
+     * @var string
+     */
+    protected const SOURCE = 'source';
+
+    /**
+     * @var string
+     */
+    protected const VALUE = 'value';
+
+    /**
+     * @var string
+     */
+    protected const WIRE = 'wire';
+
+    /**
+     * @var string
+     */
+    protected const UN_WIRE = 'unwire';
+
+    /**
+     * @param array<\PhpParser\Node> $syntaxTree
+     *
+     * @return string
+     */
+    protected function getNameSpace(array $syntaxTree): string
+    {
+        $classStatement = $this->getClassStatement($syntaxTree);
+
+        return '\\' . $classStatement->extends->toString();
+    }
+
+    /**
+     * @param array<\PhpParser\Node> $syntaxTree
+     *
+     * @throws \SprykerSdk\Integrator\ManifestGenerator\Exception\SyntaxTreeException
+     *
+     * @return \PhpParser\Node\Stmt\Class_
+     */
+    protected function getClassStatement(array $syntaxTree): Class_
+    {
+        /** @var \PhpParser\Node\Stmt\Class_|null $node */
+        $node = (new NodeFinder())->findFirst($syntaxTree, function (Node $node) {
+            return $node instanceof Class_;
+        });
+
+        if (!$node) {
+            throw new SyntaxTreeException('Can\'t get class statement from syntax tree');
+        }
+
+        return $node;
+    }
+
+    /**
+     * @return \PhpParser\Parser
+     */
+    protected function createParser(): Parser
+    {
+        return (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+    }
+
+    /**
+     * @param string $fileName
+     *
+     * @return array<\PhpParser\Node>
+     */
+    protected function buildSyntaxTree(string $fileName): array
+    {
+        if (!file_exists($fileName)) {
+            return [];
+        }
+
+        $parser = $this->createParser();
+        $originalAst = $parser->parse(file_get_contents($fileName));
+
+        $nodeTraverser = new NodeTraverser();
+        $nodeTraverser->addVisitor(new NameResolver());
+
+        return $nodeTraverser->traverse($originalAst);
+    }
+
+    /**
+     * @param string $namespace
+     *
+     * @return array<string>
+     */
+    protected function getOrganizationAndModuleName(string $namespace): array
+    {
+        $namespaceParts = explode('\\', $namespace);
+
+        return [$namespaceParts[1], $namespaceParts[3]];
+    }
+
+    /**
+     * @param array $syntaxTree
+     * @param string $methodName
+     *
+     * @return \PhpParser\Node\Stmt\ClassMethod|null
+     */
+    protected function findClassMethod(array $syntaxTree, string $methodName): ?ClassMethod
+    {
+        /** @var \PhpParser\Node\Stmt\ClassMethod|null $node */
+        $node = (new NodeFinder())->findFirst($syntaxTree, function (Node $node) use ($methodName) {
+            return $node instanceof ClassMethod
+                && $node->name->toString() === $methodName;
+        });
+
+        return $node;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr $expr
+     *
+     * @return \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ExtractedValueObject
+     */
+    protected function extractValueFromExpression(Expr $expr): ExtractedValueObject
+    {
+        $valueExtractorCollection = $this->createValueExtractorStrategyCollection();
+
+        return $valueExtractorCollection->execute($expr);
+    }
+
+    /**
+     * @return \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ValueExtractorStrategyCollection
+     */
+    protected function createValueExtractorStrategyCollection(): ValueExtractorStrategyCollection
+    {
+        return new ValueExtractorStrategyCollection();
+    }
+}

--- a/src/ManifestGenerator/ArrayConfigElementManifestStrategy.php
+++ b/src/ManifestGenerator/ArrayConfigElementManifestStrategy.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator;
+
+use SprykerSdk\Integrator\ManifestGenerator\ArrayElementExtractor\ArrayElementNamespaceExtractor\ConstArrayElementNamespaceExtractor;
+use SprykerSdk\Integrator\ManifestGenerator\ArrayElementExtractor\ConstExtractor;
+use PhpParser\Node\Stmt;
+
+class ArrayConfigElementManifestStrategy extends AbstractManifestStrategy implements ManifestStrategyInterface
+{
+    /**
+     * @var string
+     */
+    public const MANIFEST_KEY = 'add-config-array-element';
+
+    /**
+     * @var array<string>
+     */
+    protected const APPLICATION_LAYERS = [
+        'Yves',
+        'Zed',
+        'Client',
+        'Service',
+        'Shared',
+    ];
+
+    /**
+     * @param string $fileName
+     *
+     * @return bool
+     */
+    public function isApplicable(string $fileName): bool
+    {
+        $regex = sprintf(
+            '/.+\/src\/[a-zA-Z]+\/(%s)\/[a-zA-Z]+\/[a-zA-Z]+Config\.php/',
+            implode('|', static::APPLICATION_LAYERS),
+        );
+
+        return preg_match($regex, $fileName);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function generateManifestData(string $fileName, string $originalFileName, array $existingChanges = []): array
+    {
+        $syntaxTree = $this->buildSyntaxTree($fileName);
+        $originalSyntaxTree = $this->buildSyntaxTree($originalFileName);
+
+        $data = $this->compareClasses($syntaxTree, $originalSyntaxTree);
+
+        return $this->buildManifestArray($data, $this->getNameSpace($syntaxTree), $existingChanges);
+    }
+
+    /**
+     * @param array<\PhpParser\Node> $currentSyntaxTree
+     * @param array<\PhpParser\Node> $originalSyntaxTree
+     *
+     * @return array<string, array>
+     */
+    protected function compareClasses(array $currentSyntaxTree, array $originalSyntaxTree): array
+    {
+        $originalClassMethods = [];
+        if ($originalSyntaxTree) {
+            $originalClass = $this->getClassStatement($originalSyntaxTree);
+            $originalClassMethods = $this->indexMethodsByName($originalClass->getMethods());
+        }
+
+        $currentClassMethods = [];
+        if ($currentSyntaxTree) {
+            $currentClass = $this->getClassStatement($currentSyntaxTree);
+            $currentClassMethods = $this->indexMethodsByName($currentClass->getMethods());
+        }
+
+        return $this->gatherArrayElementsIndexedByMethod($currentClassMethods, $originalClassMethods);
+    }
+
+    /**
+     * @param array<\PhpParser\Node\Stmt\ClassMethod> $classMethods
+     *
+     * @return array<string, \PhpParser\Node\Stmt\ClassMethod>
+     */
+    protected function indexMethodsByName(array $classMethods): array
+    {
+        $indexedClassMethods = [];
+
+        foreach ($classMethods as $classMethod) {
+            $indexedClassMethods[$classMethod->name->toString()] = $classMethod;
+        }
+
+        return $indexedClassMethods;
+    }
+
+    /**
+     * @param array<\PhpParser\Node\Stmt\ClassMethod> $classMethods
+     * @param array<\PhpParser\Node\Stmt\ClassMethod> $classMethodsToCompare
+     *
+     * @return array<string, array<string>>
+     */
+    protected function gatherArrayElementsIndexedByMethod(array $classMethods, array $classMethodsToCompare): array
+    {
+        $result = [];
+
+        foreach ($classMethods as $methodName => $classMethod) {
+            $extractorStack = $this->createArrayElementExtractorStack();
+
+            $arrayElementsFromClass = $this->extractArrayElementsList($classMethod->stmts[0], $extractorStack);
+            $arrayElementsFromClassToCompare = [];
+            if (isset($classMethodsToCompare[$methodName])) {
+                $arrayElementsFromClassToCompare = $this->extractArrayElementsList(
+                    $classMethodsToCompare[$methodName]->stmts[0],
+                    $extractorStack,
+                );
+            }
+
+            $arrayElementsDiff = array_diff($arrayElementsFromClass, $arrayElementsFromClassToCompare);
+
+            if ($arrayElementsDiff) {
+                $result[$methodName] = $arrayElementsDiff;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<\SprykerSdk\Integrator\ManifestGenerator\ArrayElementExtractor\ArrayElementExtractorInterface>
+     */
+    protected function createArrayElementExtractorStack(): array
+    {
+        return [
+            new ConstExtractor(),
+        ];
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt $statement
+     * @param array<\SprykerSdk\Integrator\ManifestGenerator\ArrayElementExtractor\ArrayElementExtractorInterface> $extractors
+     *
+     * @return array
+     */
+    protected function extractArrayElementsList(Stmt $statement, array $extractors): array
+    {
+        $arrayElements = [];
+        foreach ($extractors as $extractor) {
+            if ($extractor->isApplicable($statement)) {
+                $arrayElements = array_merge($extractor->extract($statement->expr), $arrayElements);
+            }
+        }
+
+        return $arrayElements;
+    }
+
+    /**
+     * @param array<string, array> $arrayElementChanges
+     * @param string $namespace
+     * @param array<string, array> $manifests
+     *
+     * @return array<string, array>
+     */
+    protected function buildManifestArray(array $arrayElementChanges, string $namespace, array $manifests): array
+    {
+        $namespaceExtractors = $this->getNamespaceExtractorCollection();
+        foreach ($arrayElementChanges as $methodName => $arrayElements) {
+            foreach ($arrayElements as $arrayElement) {
+                $targetNamespace = $this->findArrayElementNamespace($arrayElement, $namespaceExtractors);
+                if (!$targetNamespace) {
+                    $targetNamespace = $namespace;
+                }
+                [$organization, $module] = $this->getOrganizationAndModuleName($targetNamespace);
+                $manifests[$organization . '.' . $module][static::MANIFEST_KEY][] = [
+                    static::TARGET => sprintf('%s::%s', $namespace, $methodName),
+                    static::VALUE => $arrayElement,
+                ];
+            }
+        }
+
+        return $manifests;
+    }
+
+    /**
+     * @return array<\SprykerSdk\Integrator\ManifestGenerator\ArrayElementExtractor\ArrayElementNamespaceExtractor\ArrayElementNamespaceExtractorInterface>
+     */
+    protected function getNamespaceExtractorCollection(): array
+    {
+        return [
+            new ConstArrayElementNamespaceExtractor(),
+        ];
+    }
+
+    /**
+     * @param mixed $arrayElement
+     * @param array<\SprykerSdk\Integrator\ManifestGenerator\ArrayElementExtractor\ArrayElementNamespaceExtractor\ArrayElementNamespaceExtractorInterface> $namespaceArrayExtractorCollection
+     *
+     * @return string|null
+     */
+    protected function findArrayElementNamespace($arrayElement, array $namespaceArrayExtractorCollection): ?string
+    {
+        foreach ($namespaceArrayExtractorCollection as $namespaceArrayExtractor) {
+            if ($namespaceArrayExtractor->isApplicable($arrayElement)) {
+                return $namespaceArrayExtractor->extractNamespace($arrayElement);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ManifestGenerator/ArrayElementExtractor/ArrayElementExtractorInterface.php
+++ b/src/ManifestGenerator/ArrayElementExtractor/ArrayElementExtractorInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ArrayElementExtractor;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
+
+interface ArrayElementExtractorInterface
+{
+    /**
+     * @param \PhpParser\Node\Stmt $statement
+     *
+     * @return bool
+     */
+    public function isApplicable(Stmt $statement): bool;
+
+    /**
+     * @param \PhpParser\Node\Expr $expr
+     *
+     * @return array
+     */
+    public function extract(Expr $expr): array;
+}

--- a/src/ManifestGenerator/ArrayElementExtractor/ArrayElementNamespaceExtractor/ArrayElementNamespaceExtractorInterface.php
+++ b/src/ManifestGenerator/ArrayElementExtractor/ArrayElementNamespaceExtractor/ArrayElementNamespaceExtractorInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ArrayElementExtractor\ArrayElementNamespaceExtractor;
+
+interface ArrayElementNamespaceExtractorInterface
+{
+    /**
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function isApplicable($value): bool;
+
+    /**
+     * @param mixed $value
+     *
+     * @return string|null
+     */
+    public function extractNamespace($value): ?string;
+}

--- a/src/ManifestGenerator/ArrayElementExtractor/ArrayElementNamespaceExtractor/ConstArrayElementNamespaceExtractor.php
+++ b/src/ManifestGenerator/ArrayElementExtractor/ArrayElementNamespaceExtractor/ConstArrayElementNamespaceExtractor.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ArrayElementExtractor\ArrayElementNamespaceExtractor;
+
+class ConstArrayElementNamespaceExtractor implements ArrayElementNamespaceExtractorInterface
+{
+    /**
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function isApplicable($value): bool
+    {
+        return is_string($value) && strpos($value, '::') !== false;
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return string|null
+     */
+    public function extractNamespace($value): ?string
+    {
+        $constantParts = explode('::', $value);
+
+        return $constantParts[0];
+    }
+}

--- a/src/ManifestGenerator/ArrayElementExtractor/ConstExtractor.php
+++ b/src/ManifestGenerator/ArrayElementExtractor/ConstExtractor.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ArrayElementExtractor;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Return_;
+
+class ConstExtractor implements ArrayElementExtractorInterface
+{
+    /**
+     * @param \PhpParser\Node\Stmt $statement
+     *
+     * @return bool
+     */
+    public function isApplicable(Stmt $statement): bool
+    {
+        return $statement instanceof Return_ && $statement->expr instanceof Array_;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\Array_ $expr
+     *
+     * @return array<string>
+     */
+    public function extract(Expr $expr): array
+    {
+        $array = [];
+        foreach ($expr->items as $item) {
+            if ($item->value instanceof ClassConstFetch) {
+                $array[] = sprintf('\\%s::%s', $item->value->class->toString(), $item->value->name->toString());
+            }
+        }
+
+        return $array;
+    }
+}

--- a/src/ManifestGenerator/EnvConfigManifestStrategy.php
+++ b/src/ManifestGenerator/EnvConfigManifestStrategy.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator;
+
+use SprykerSdk\Integrator\ManifestGenerator\Exception\ValueExtractorException;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Expression;
+
+class EnvConfigManifestStrategy extends AbstractManifestStrategy implements ManifestStrategyInterface
+{
+    /**
+     * @var string
+     */
+    public const MANIFEST_KEY = 'configure-env';
+
+    /**
+     * @inheritDoc
+     */
+    public function isApplicable(string $fileName): bool
+    {
+        return preg_match('#.+/config/Shared/config[a-zA-Z_-]{0,}\.php#', $fileName);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function generateManifestData(string $fileName, string $originalFileName, array $existingChanges = []): array
+    {
+        $syntaxTree = $this->buildSyntaxTree($fileName);
+        $originalSyntaxTree = [];
+
+        if (file_exists($originalFileName)) {
+            $originalSyntaxTree = $this->buildSyntaxTree($originalFileName);
+        }
+
+        $data = $this->compareFiles($syntaxTree, $originalSyntaxTree);
+
+        return $this->buildManifestArray($data, $existingChanges);
+    }
+
+    /**
+     * @param array<\PhpParser\Node> $currentSyntaxTree
+     * @param array<\PhpParser\Node> $originalSyntaxTree
+     *
+     * @return array<array<string, string>>
+     */
+    protected function compareFiles(array $currentSyntaxTree, array $originalSyntaxTree): array
+    {
+        $originalExpressions = [];
+        if ($originalSyntaxTree) {
+            $originalExpressions = $this->getExpressions($originalSyntaxTree);
+        }
+        $currentExpressions = $this->getExpressions($currentSyntaxTree);
+
+        return $this->compareExpressions($currentExpressions, $originalExpressions);
+    }
+
+    /**
+     * @param array<\PhpParser\Node> $syntaxTree
+     *
+     * @return array<string, string>
+     */
+    protected function getExpressions(array $syntaxTree): array
+    {
+        $expressions = [];
+        /** @var \PhpParser\Node\Stmt\Expression $expression */
+        foreach ($syntaxTree as $expression) {
+            if (!$this->assertStatement($expression)) {
+                continue;
+            }
+
+            /** @var \PhpParser\Node\Expr\Assign $assignExpression */
+            $assignExpression = $expression->expr;
+            /** @var \PhpParser\Node\Expr\ArrayDimFetch $arrayDimFetchExpression */
+            $arrayDimFetchExpression = $assignExpression->var;
+            /** @var \PhpParser\Node\Expr\ClassConstFetch $constant */
+            $constant = $arrayDimFetchExpression->dim;
+            $key = sprintf('\%s::%s', $constant->class->toString(), $constant->name->toString());
+
+            try {
+                $extractedValueObject = $this->extractValueFromExpression($assignExpression->expr);
+            } catch (ValueExtractorException $exception) {
+                // Not supported (yet)
+                continue;
+            }
+
+            $value = $extractedValueObject->getValue();
+            if ($extractedValueObject->isLiteral()) {
+                $value = [
+                    'value' => $extractedValueObject->getValue(),
+                    'is_literal' => true,
+                ];
+            }
+            $expressions[$key] = $value;
+        }
+
+        return $expressions;
+    }
+
+    /**
+     * @param array $expressions
+     * @param array $expressionsToCompare
+     *
+     * @return array<array<string, string>>
+     */
+    protected function compareExpressions(array $expressions, array $expressionsToCompare): array
+    {
+        $diffExpressions = [];
+        foreach ($expressions as $key => $value) {
+            if (isset($expressionsToCompare[$key]) && $expressionsToCompare[$key] === $value) {
+                continue;
+            }
+
+            $diffExpressions[] = [
+                static::TARGET => $key,
+                static::VALUE => $value,
+            ];
+        }
+
+        return $diffExpressions;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param array<string, array> $manifests
+     *
+     * @return array<string, array>
+     */
+    protected function buildManifestArray(array $data, array $manifests): array
+    {
+        foreach ($data as $changes) {
+            [$organization, $module] = $this->getOrganizationAndModuleName($changes[static::TARGET]);
+            $manifests[$organization . '.' . $module][static::MANIFEST_KEY][] = $changes;
+        }
+
+        return $manifests;
+    }
+
+    /**
+     * @param \PhpParser\Node $statement
+     *
+     * @return bool
+     */
+    protected function assertStatement(Node $statement): bool
+    {
+        return $statement instanceof Expression
+            && $statement->expr instanceof Assign
+            && $statement->expr->var instanceof ArrayDimFetch
+            && $statement->expr->var->dim instanceof ClassConstFetch
+            && $statement->expr->var->var instanceof Variable
+            && $statement->expr->var->var->name === 'config';
+    }
+}

--- a/src/ManifestGenerator/Exception/SyntaxTreeException.php
+++ b/src/ManifestGenerator/Exception/SyntaxTreeException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\Exception;
+
+use Exception;
+
+class SyntaxTreeException extends Exception
+{
+}

--- a/src/ManifestGenerator/Exception/ValueExtractorException.php
+++ b/src/ManifestGenerator/Exception/ValueExtractorException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\Exception;
+
+use Exception;
+
+class ValueExtractorException extends Exception
+{
+}

--- a/src/ManifestGenerator/GlossaryKeyManifestStrategy.php
+++ b/src/ManifestGenerator/GlossaryKeyManifestStrategy.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator;
+
+use League\Csv\Reader;
+use SprykerSdk\Integrator\Common\UtilText\Filter\SeparatorToCamelCase;
+
+class GlossaryKeyManifestStrategy extends AbstractManifestStrategy implements ManifestStrategyInterface
+{
+    /**
+     * @var string
+     */
+    public const MANIFEST_KEY = 'glossary-key';
+
+    /**
+     * @var string
+     */
+    public const MANIFEST_KEY_NEW = 'new';
+
+    /**
+     * @param string $fileName
+     *
+     * @return bool
+     */
+    public function isApplicable(string $fileName): bool
+    {
+        return (bool)preg_match('#/glossary\.csv#', $fileName);
+    }
+
+    /**
+     * @param string $fileName
+     * @param string $originalFileName
+     * @param array<string, array> $existingChanges
+     *
+     * @return array<string, array>
+     */
+    public function generateManifestData(string $fileName, string $originalFileName, array $existingChanges = []): array
+    {
+        $glossaryKeysAfter = $this->parseCsvFile($fileName);
+        $glossaryKeyBefore = [];
+
+        if (file_exists($originalFileName)) {
+            $glossaryKeyBefore = $this->parseCsvFile($originalFileName);
+        }
+
+        $data = $this->compareFiles($glossaryKeyBefore, $glossaryKeysAfter);
+
+        return $this->buildManifestArray($data, $existingChanges);
+    }
+
+    /**
+     * @param string $fileName
+     *
+     * @return array<string, array<string, string>>
+     */
+    protected function parseCsvFile(string $fileName): array
+    {
+        $csv = Reader::createFromPath($fileName);
+
+        $rows = [];
+        foreach ($csv as $row) {
+            $rows[$row[0]][$row[2]] = $row[1];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string, array<string, string>> $before
+     * @param array<string, array<string, string>> $after
+     *
+     * @return array<string, array>
+     */
+    protected function compareFiles(array $before, array $after): array
+    {
+        $newKeys = [];
+        foreach ($after as $key => $data) {
+            if (!isset($before[$key])) {
+                $newKeys[] = $key;
+            }
+        }
+
+        if (!$newKeys) {
+            return [];
+        }
+
+        return $this->gatherGlossaryKeys($before, $after, $newKeys);
+    }
+
+    /**
+     * @param array<string, array<string, string>> $before
+     * @param array<string, array<string, string>> $after
+     * @param array<string> $newKeys
+     *
+     * @return array<string, array>
+     */
+    protected function gatherGlossaryKeys(array $before, array $after, array $newKeys): array
+    {
+        $keys = [];
+
+        foreach ($newKeys as $newKey) {
+            $keys[$newKey] = $after[$newKey];
+        }
+
+        return $keys;
+    }
+
+    /**
+     * @param array<string, array> $data
+     * @param array<string, array> $manifests
+     *
+     * @return array<string, array>
+     */
+    protected function buildManifestArray(array $data, array $manifests): array
+    {
+        foreach ($data as $key => $changes) {
+            [$organization, $module] = $this->getOrganizationAndModuleNameFromGlossaryKey($key);
+            $manifests[$organization . '.' . $module][static::MANIFEST_KEY][static::MANIFEST_KEY_NEW][$key] = $changes;
+        }
+
+        return $manifests;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return array<string>
+     */
+    protected function getOrganizationAndModuleNameFromGlossaryKey(string $key): array
+    {
+        $pos = strpos($key, '.');
+        $moduleName = null;
+        if ($pos) {
+            $separatorToCamelCaseFilter = new SeparatorToCamelCase();
+            $moduleName = $separatorToCamelCaseFilter->filter(substr($key, 0, $pos));
+        }
+
+        $namespace = '?';
+
+        return [$namespace, $moduleName ?: '?'];
+    }
+}

--- a/src/ManifestGenerator/GlueRelationshipManifestStrategy.php
+++ b/src/ManifestGenerator/GlueRelationshipManifestStrategy.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator;
+
+use SprykerSdk\Integrator\ManifestGenerator\Exception\SyntaxTreeException;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Stmt\Expression;
+
+class GlueRelationshipManifestStrategy extends AbstractManifestStrategy implements ManifestStrategyInterface
+{
+    /**
+     * @var string
+     */
+    public const MANIFEST_KEY_WIRE = 'wire-glue-relationship';
+
+    /**
+     * @var string
+     */
+    public const MANIFEST_KEY_UNWIRE = 'unwire-glue-relationship';
+
+    /**
+     * @var string
+     */
+    protected const RELATIONSHIP_METHOD_NAME = 'getResourceRelationshipPlugins';
+
+    /**
+     * @var string
+     */
+    protected const DATA_KEY_CONFIG = 'config';
+
+    /**
+     * @var string
+     */
+    protected const DATA_KEY_PLUGIN = 'plugin';
+
+    /**
+     * @inheritDoc
+     */
+    public function isApplicable(string $fileName): bool
+    {
+        return strpos($fileName, 'GlueApplicationDependencyProvider.php') !== false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function generateManifestData(string $fileName, string $originalFileName, array $existingChanges = []): array
+    {
+        $syntaxTree = $this->buildSyntaxTree($fileName);
+        $originalSyntaxTree = [];
+
+        if (file_exists($originalFileName)) {
+            $originalSyntaxTree = $this->buildSyntaxTree($originalFileName);
+        }
+
+        $data = $this->compareFiles($syntaxTree, $originalSyntaxTree);
+
+        return $this->buildManifestArray($data, $existingChanges);
+    }
+
+    /**
+     * @param array<\PhpParser\Node> $currentSyntaxTree
+     * @param array<\PhpParser\Node> $originalSyntaxTree
+     *
+     * @throws \SprykerSdk\Integrator\ManifestGenerator\Exception\SyntaxTreeException
+     *
+     * @return array<string, array>
+     */
+    protected function compareFiles(array $currentSyntaxTree, array $originalSyntaxTree): array
+    {
+        $originalRelationData = [];
+        if ($originalSyntaxTree) {
+            $originalMethod = $this->findClassMethod($originalSyntaxTree, static::RELATIONSHIP_METHOD_NAME);
+            if ($originalMethod) {
+                $originalRelationData = $this->extractRelationList($originalMethod->stmts);
+            }
+        }
+
+        $currentMethod = $this->findClassMethod($currentSyntaxTree, static::RELATIONSHIP_METHOD_NAME);
+        if (!$currentMethod) {
+            throw new SyntaxTreeException(sprintf('Can\'t find %s method in the GlueApplicationDependencyProvider class', static::RELATIONSHIP_METHOD_NAME));
+        }
+        $currentRelationData = $this->extractRelationList($currentMethod->stmts);
+
+        return [
+            static::WIRE => $this->gatherRelations($currentRelationData, $originalRelationData),
+            static::UN_WIRE => $this->gatherRelations($originalRelationData, $currentRelationData),
+
+        ];
+    }
+
+    /**
+     * @param array $relationData
+     * @param array $relationDataToCompare
+     *
+     * @return array
+     */
+    protected function gatherRelations(array $relationData, array $relationDataToCompare): array
+    {
+        $result = [];
+        foreach ($relationData as $relationKey => $relationPlugins) {
+            $plugins = !isset($relationDataToCompare[$relationKey]) ? $relationPlugins : array_diff($relationPlugins, $relationDataToCompare[$relationKey]);
+            if (!$plugins) {
+                continue;
+            }
+            foreach ($plugins as $plugin) {
+                $result[] = [static::DATA_KEY_CONFIG => $relationKey, static::DATA_KEY_PLUGIN => $plugin];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<\PhpParser\Node\Stmt> $expressions
+     *
+     * @return array
+     */
+    protected function extractRelationList(array $expressions): array
+    {
+        $data = [];
+        foreach ($expressions as $expression) {
+            if (!($expression instanceof Expression) || !($expression->expr instanceof MethodCall) || $expression->expr->name->name !== 'addRelationship') {
+                continue;
+            }
+
+            /** @var \PhpParser\Node\Expr\ClassConstFetch $constantExpression */
+            $constantExpression = $expression->expr->args[0]->value;
+            /** @var \PhpParser\Node\Expr\New_ $pluginExpression */
+            $pluginExpression = $expression->expr->args[1]->value;
+            $constName = sprintf('\\%s::%s', $constantExpression->class->toString(), $constantExpression->name->toString());
+            $data[$constName][] = '\\' . $pluginExpression->class->toString();
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param array<string, array<string, array>> $data
+     * @param array<string, array> $manifests
+     *
+     * @return array<string, array>
+     */
+    protected function buildManifestArray(array $data, array $manifests): array
+    {
+        foreach ($data as $type => $changes) {
+            foreach ($changes as $record) {
+                [$organization, $module] = $this->getOrganizationAndModuleName($record[static::DATA_KEY_PLUGIN]);
+                $manifestKey = $type === static::WIRE ? static::MANIFEST_KEY_WIRE : static::MANIFEST_KEY_UNWIRE;
+                $manifests[$organization . '.' . $module][$manifestKey][] = [
+                    static::SOURCE => [
+                        $record[static::DATA_KEY_CONFIG] => $record[static::DATA_KEY_PLUGIN],
+                    ],
+                ];
+            }
+        }
+
+        return $manifests;
+    }
+}

--- a/src/ManifestGenerator/ManifestStrategyInterface.php
+++ b/src/ManifestGenerator/ManifestStrategyInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator;
+
+interface ManifestStrategyInterface
+{
+    /**
+     * @param string $fileName
+     *
+     * @return bool
+     */
+    public function isApplicable(string $fileName): bool;
+
+    /**
+     * @param string $fileName
+     * @param string $originalFileName
+     * @param array<string, array> $existingChanges
+     *
+     * @return array<string, array>
+     */
+    public function generateManifestData(string $fileName, string $originalFileName, array $existingChanges = []): array;
+}

--- a/src/ManifestGenerator/ModuleConfigManifestStrategy.php
+++ b/src/ManifestGenerator/ModuleConfigManifestStrategy.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator;
+
+use SprykerSdk\Integrator\ManifestGenerator\Exception\ValueExtractorException;
+use PhpParser\Node\Stmt\Return_;
+
+class ModuleConfigManifestStrategy extends AbstractManifestStrategy implements ManifestStrategyInterface
+{
+    /**
+     * @var string
+     */
+    public const MANIFEST_KEY = 'configure-module';
+
+    /**
+     * @var array<string>
+     */
+    protected const APPLICATION_LAYERS = [
+        'Yves',
+        'Zed',
+        'Client',
+        'Service',
+        'Shared',
+    ];
+
+    /**
+     * @param string $fileName
+     *
+     * @return bool
+     */
+    public function isApplicable(string $fileName): bool
+    {
+        $regex = sprintf('/.+\/src\/[a-zA-Z]+\/(%s)\/[a-zA-Z]+\/[a-zA-Z]+Config\.php/', implode('|', static::APPLICATION_LAYERS));
+
+        return preg_match($regex, $fileName);
+    }
+
+    /**
+     * @param string $fileName
+     * @param string $originalFileName
+     * @param array $existingChanges
+     *
+     * @return array
+     */
+    public function generateManifestData(string $fileName, string $originalFileName, array $existingChanges = []): array
+    {
+        $syntaxTree = $this->buildSyntaxTree($fileName);
+        $originalSyntaxTree = [];
+
+        if (file_exists($originalFileName)) {
+            $originalSyntaxTree = $this->buildSyntaxTree($originalFileName);
+        }
+
+        $data = $this->compareClasses($syntaxTree, $originalSyntaxTree);
+
+        return $this->buildManifestArray($data, $existingChanges);
+    }
+
+    /**
+     * @param array<\PhpParser\Node> $currentSyntaxTree
+     * @param array<\PhpParser\Node> $originalSyntaxTree
+     *
+     * @return array<string, array>
+     */
+    protected function compareClasses(array $currentSyntaxTree, array $originalSyntaxTree): array
+    {
+        $originalClassMethods = [];
+        $originalClassConstants = [];
+        $namespace = $this->getNameSpace($currentSyntaxTree);
+        if ($originalSyntaxTree) {
+            $originalClass = $this->getClassStatement($originalSyntaxTree);
+            $originalClassMethods = $this->indexMethodsByName($originalClass->getMethods());
+            $originalClassConstants = $this->indexConstantByName($originalClass->getConstants());
+        }
+        $currentClass = $this->getClassStatement($currentSyntaxTree);
+        $currentClassMethods = $this->indexMethodsByName($currentClass->getMethods());
+        $currentClassConstants = $this->indexConstantByName($currentClass->getConstants());
+
+        return array_merge(
+            $this->gatherConfigMethods($currentClassMethods, $originalClassMethods, $namespace),
+            $this->gatherConstants($currentClassConstants, $originalClassConstants, $namespace),
+        );
+    }
+
+    /**
+     * @param array<\PhpParser\Node\Stmt\ClassMethod> $classMethods
+     *
+     * @return array<string, \PhpParser\Node\Stmt\ClassMethod>
+     */
+    protected function indexMethodsByName(array $classMethods): array
+    {
+        $indexedClassMethods = [];
+
+        foreach ($classMethods as $classMethod) {
+            $indexedClassMethods[$classMethod->name->toString()] = $classMethod;
+        }
+
+        return $indexedClassMethods;
+    }
+
+    /**
+     * @param array<\PhpParser\Node\Stmt\ClassConst> $classConstants
+     *
+     * @return array<string, \PhpParser\Node\Const_>
+     */
+    protected function indexConstantByName(array $classConstants): array
+    {
+        $indexedClassConstants = [];
+        foreach ($classConstants as $classConstant) {
+            foreach ($classConstant->consts as $constant) {
+                $indexedClassConstants[$constant->name->toString()] = $constant;
+            }
+        }
+
+        return $indexedClassConstants;
+    }
+
+    /**
+     * @param array<string, \PhpParser\Node\Stmt\ClassMethod> $currentMethods
+     * @param array<string, \PhpParser\Node\Stmt\ClassMethod> $existingMethods
+     * @param string $namespace
+     *
+     * @return array
+     */
+    protected function gatherConfigMethods(array $currentMethods, array $existingMethods, string $namespace): array
+    {
+        $methods = [];
+        foreach ($currentMethods as $methodName => $method) {
+            if (isset($existingMethods[$methodName]) || !($method->stmts[0] instanceof Return_)) {
+                continue;
+            }
+
+            try {
+                $extractedValueObject = $this->extractValueFromExpression($method->stmts[0]->expr);
+            } catch (ValueExtractorException $exception) {
+                // Not supported (yet)
+                continue;
+            }
+
+            $value = $extractedValueObject->getValue();
+            if ($extractedValueObject->isLiteral()) {
+                $value = [
+                    'value' => $extractedValueObject->getValue(),
+                    'is_literal' => true,
+                ];
+            }
+
+            $methods[] = [
+                static::TARGET => sprintf('%s::%s', $namespace, $methodName),
+                static::VALUE => $value,
+            ];
+        }
+
+        return $methods;
+    }
+
+    /**
+     * @param array<string, \PhpParser\Node\Const_> $currentConstants
+     * @param array<string, \PhpParser\Node\Const_> $existingConstants
+     * @param string $namespace
+     *
+     * @return array
+     */
+    protected function gatherConstants(array $currentConstants, array $existingConstants, string $namespace): array
+    {
+        $constants = [];
+
+        foreach ($currentConstants as $constantName => $constant) {
+            if (isset($existingConstants[$constantName])) {
+                continue;
+            }
+
+            try {
+                $extractedValueObject = $this->extractValueFromExpression($constant->value);
+            } catch (ValueExtractorException $exception) {
+                Log::write(
+                    'info',
+                    sprintf(
+                        'Error in value extraction in a config constant %s. %s value expression is not supported.',
+                        $constantName,
+                        get_class($constant->value),
+                    ),
+                );
+
+                continue;
+            }
+
+            $value = $extractedValueObject->getValue();
+            if ($extractedValueObject->isLiteral()) {
+                $value = [
+                    'value' => $extractedValueObject->getValue(),
+                    'is_literal' => true,
+                ];
+            }
+
+            $constants[] = [
+                static::TARGET => sprintf('%s::%s', $namespace, $constantName),
+                static::VALUE => $value,
+            ];
+        }
+
+        return $constants;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param array<string, array> $manifests
+     *
+     * @return array<string, array>
+     */
+    protected function buildManifestArray(array $data, array $manifests): array
+    {
+        foreach ($data as $changes) {
+            [$organization, $module] = $this->getOrganizationAndModuleName($changes[static::TARGET]);
+            $manifests[$organization . '.' . $module][static::MANIFEST_KEY][] = $changes;
+        }
+
+        return $manifests;
+    }
+}

--- a/src/ManifestGenerator/PluginExtractor/PluginExtractorInterface.php
+++ b/src/ManifestGenerator/PluginExtractor/PluginExtractorInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\PluginExtractor;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
+
+interface PluginExtractorInterface
+{
+    /**
+     * @param \PhpParser\Node\Stmt $statement
+     *
+     * @return bool
+     */
+    public function isApplicable(Stmt $statement): bool;
+
+    /**
+     * @param \PhpParser\Node\Expr $expr
+     *
+     * @return array
+     */
+    public function extract(Expr $expr): array;
+}

--- a/src/ManifestGenerator/PluginExtractor/ReturnArrayPluginExtractor.php
+++ b/src/ManifestGenerator/PluginExtractor/ReturnArrayPluginExtractor.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\PluginExtractor;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Return_;
+
+class ReturnArrayPluginExtractor implements PluginExtractorInterface
+{
+    /**
+     * @param \PhpParser\Node\Stmt $statement
+     *
+     * @return bool
+     */
+    public function isApplicable(Stmt $statement): bool
+    {
+        return $statement instanceof Return_ && $statement->expr instanceof Array_;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\Array_ $expr
+     *
+     * @return array
+     */
+    public function extract(Expr $expr): array
+    {
+        $array = [];
+        foreach ($expr->items as $item) {
+            if ($item->value instanceof New_) {
+                $array[] = '\\' . $item->value->class->toString();
+            }
+        }
+
+        return $array;
+    }
+}

--- a/src/ManifestGenerator/PluginExtractor/ReturnClassPluginExtractor.php
+++ b/src/ManifestGenerator/PluginExtractor/ReturnClassPluginExtractor.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\PluginExtractor;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Return_;
+
+class ReturnClassPluginExtractor implements PluginExtractorInterface
+{
+    /**
+     * @param \PhpParser\Node\Stmt $statement
+     *
+     * @return bool
+     */
+    public function isApplicable(Stmt $statement): bool
+    {
+        return $statement instanceof Return_ && $statement->expr instanceof New_;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\New_ $expr
+     *
+     * @return array
+     */
+    public function extract(Expr $expr): array
+    {
+        return ['\\' . $expr->class->toString()];
+    }
+}

--- a/src/ManifestGenerator/PluginExtractor/VariableArrayPluginExtractor.php
+++ b/src/ManifestGenerator/PluginExtractor/VariableArrayPluginExtractor.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\PluginExtractor;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Expression;
+
+class VariableArrayPluginExtractor implements PluginExtractorInterface
+{
+    /**
+     * @param \PhpParser\Node\Stmt $statement
+     *
+     * @return bool
+     */
+    public function isApplicable(Stmt $statement): bool
+    {
+        return $statement instanceof Expression && $statement->expr instanceof Assign && $statement->expr->expr instanceof Array_;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\Assign $expr
+     *
+     * @return array
+     */
+    public function extract(Expr $expr): array
+    {
+        $extractor = $this->createReturnArrayExtractor();
+
+        return $extractor->extract($expr->expr);
+    }
+
+    /**
+     * @return \SprykerSdk\Integrator\ManifestGenerator\PluginExtractor\PluginExtractorInterface
+     */
+    protected function createReturnArrayExtractor(): PluginExtractorInterface
+    {
+        return new ReturnArrayPluginExtractor();
+    }
+}

--- a/src/ManifestGenerator/PluginsManifestStrategy.php
+++ b/src/ManifestGenerator/PluginsManifestStrategy.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator;
+
+use SprykerSdk\Integrator\ManifestGenerator\PluginExtractor\ReturnArrayPluginExtractor;
+use SprykerSdk\Integrator\ManifestGenerator\PluginExtractor\ReturnClassPluginExtractor;
+use SprykerSdk\Integrator\ManifestGenerator\PluginExtractor\VariableArrayPluginExtractor;
+use PhpParser\Node\Stmt;
+
+class PluginsManifestStrategy extends AbstractManifestStrategy implements ManifestStrategyInterface
+{
+    /**
+     * @var string
+     */
+    public const MANIFEST_KEY_WIRE = 'wire-plugin';
+
+    /**
+     * @var string
+     */
+    public const MANIFEST_KEY_UNWIRE = 'unwire-plugin';
+
+    /**
+     * @param string $fileName
+     *
+     * @return bool
+     */
+    public function isApplicable(string $fileName): bool
+    {
+        return strpos($fileName, 'DependencyProvider.php') !== false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function generateManifestData(string $fileName, string $originalFileName, array $existingChanges = []): array
+    {
+        $syntaxTree = $this->buildSyntaxTree($fileName);
+        if (!$syntaxTree) {
+            return [];
+        }
+
+        $originalSyntaxTree = $this->buildSyntaxTree($originalFileName);
+
+        $data = $this->compareClasses($syntaxTree, $originalSyntaxTree);
+
+        return $this->buildManifestArray($data, $this->getNameSpace($syntaxTree), $existingChanges);
+    }
+
+    /**
+     * @param array<\PhpParser\Node> $currentSyntaxTree
+     * @param array<\PhpParser\Node> $originalSyntaxTree
+     *
+     * @return array<string, array>
+     */
+    protected function compareClasses(array $currentSyntaxTree, array $originalSyntaxTree): array
+    {
+        $originalClassMethods = [];
+        if ($originalSyntaxTree) {
+            $originalClass = $this->getClassStatement($originalSyntaxTree);
+            $originalClassMethods = $this->indexMethodsByName($originalClass->getMethods());
+        }
+        $currentClass = $this->getClassStatement($currentSyntaxTree);
+        $currentClassMethods = $this->indexMethodsByName($currentClass->getMethods());
+
+        return [
+            static::WIRE => $this->gatherPluginsIndexedByMethod($currentClassMethods, $originalClassMethods),
+            static::UN_WIRE => $this->gatherPluginsIndexedByMethod($originalClassMethods, $currentClassMethods),
+        ];
+    }
+
+    /**
+     * @param array<\PhpParser\Node\Stmt\ClassMethod> $classMethods
+     *
+     * @return array<string, \PhpParser\Node\Stmt\ClassMethod>
+     */
+    protected function indexMethodsByName(array $classMethods): array
+    {
+        $indexedClassMethods = [];
+
+        foreach ($classMethods as $classMethod) {
+            $indexedClassMethods[$classMethod->name->toString()] = $classMethod;
+        }
+
+        return $indexedClassMethods;
+    }
+
+    /**
+     * @param array<\PhpParser\Node\Stmt\ClassMethod> $classMethods
+     * @param array<\PhpParser\Node\Stmt\ClassMethod> $classMethodsToCompare
+     *
+     * @return array<string, array<string>>
+     */
+    protected function gatherPluginsIndexedByMethod(array $classMethods, array $classMethodsToCompare): array
+    {
+        $result = [];
+
+        foreach ($classMethods as $methodName => $classMethod) {
+            $extractorStack = $this->createPluginExtractorStack();
+
+            $pluginsFromClass = $this->extractPluginsList($classMethod->stmts[0], $extractorStack);
+            $pluginsFromClassToCompare = [];
+            if (isset($classMethodsToCompare[$methodName])) {
+                $pluginsFromClassToCompare = $this->extractPluginsList($classMethodsToCompare[$methodName]->stmts[0], $extractorStack);
+            }
+
+            $pluginsDiff = array_diff($pluginsFromClass, $pluginsFromClassToCompare);
+
+            if ($pluginsDiff) {
+                $result[$methodName] = $pluginsDiff;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<\SprykerSdk\Integrator\ManifestGenerator\PluginExtractor\PluginExtractorInterface>
+     */
+    protected function createPluginExtractorStack(): array
+    {
+        return [
+            new ReturnArrayPluginExtractor(),
+            new ReturnClassPluginExtractor(),
+            new VariableArrayPluginExtractor(),
+        ];
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt $statement
+     * @param array<\SprykerSdk\Integrator\ManifestGenerator\PluginExtractor\PluginExtractorInterface> $extractors
+     *
+     * @return array
+     */
+    protected function extractPluginsList(Stmt $statement, array $extractors): array
+    {
+        $plugins = [];
+        foreach ($extractors as $extractor) {
+            if ($extractor->isApplicable($statement)) {
+                $plugins = array_merge($extractor->extract($statement->expr), $plugins);
+            }
+        }
+
+        return $plugins;
+    }
+
+    /**
+     * @param array<string, array> $pluginChanges
+     * @param string $namespace
+     * @param array<string, array> $manifests
+     *
+     * @return array<string, array>
+     */
+    protected function buildManifestArray(array $pluginChanges, string $namespace, array $manifests): array
+    {
+        foreach ($pluginChanges as $type => $method) {
+            foreach ($method as $methodName => $plugins) {
+                foreach ($plugins as $plugin) {
+                    [$organization, $module] = $this->getOrganizationAndModuleName($plugin);
+                    $manifestKey = $type === static::WIRE ? static::MANIFEST_KEY_WIRE : static::MANIFEST_KEY_UNWIRE;
+                    $manifests[$organization . '.' . $module][$manifestKey][] = [
+                        static::TARGET => sprintf('%s::%s', $namespace, $methodName),
+                        static::SOURCE => $plugin,
+                    ];
+                }
+            }
+        }
+
+        return $manifests;
+    }
+}

--- a/src/ManifestGenerator/Validator/ArrayConfigElementManifestValidatorStrategy.php
+++ b/src/ManifestGenerator/Validator/ArrayConfigElementManifestValidatorStrategy.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\Validator;
+
+use SprykerSdk\Integrator\ManifestGenerator\ArrayConfigElementManifestStrategy;
+
+class ArrayConfigElementManifestValidatorStrategy implements ManifestValidatorStrategyInterface
+{
+    /**
+     * @param string $manifestKey
+     *
+     * @return bool
+     */
+    public function isApplicable(string $manifestKey): bool
+    {
+        return $manifestKey === ArrayConfigElementManifestStrategy::MANIFEST_KEY;
+    }
+
+    /**
+     * @param array $manifestData
+     *
+     * @return string|null
+     */
+    public function validate(array $manifestData): ?string
+    {
+        foreach ($manifestData as $manifestRecord) {
+            if (!array_key_exists('target', $manifestRecord)) {
+                return sprintf('Missing required key `target` in %s record', json_encode($manifestRecord));
+            }
+
+            if (!array_key_exists('value', $manifestRecord)) {
+                return sprintf('Missing required key `value` in %s record', json_encode($manifestRecord));
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ManifestGenerator/Validator/EnvConfigManifestValidatorStrategy.php
+++ b/src/ManifestGenerator/Validator/EnvConfigManifestValidatorStrategy.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\Validator;
+
+use SprykerSdk\Integrator\ManifestGenerator\EnvConfigManifestStrategy;
+
+class EnvConfigManifestValidatorStrategy implements ManifestValidatorStrategyInterface
+{
+    /**
+     * @param string $manifestKey
+     *
+     * @return bool
+     */
+    public function isApplicable(string $manifestKey): bool
+    {
+        return $manifestKey === EnvConfigManifestStrategy::MANIFEST_KEY;
+    }
+
+    /**
+     * @param array $manifestData
+     *
+     * @return string|null
+     */
+    public function validate(array $manifestData): ?string
+    {
+        foreach ($manifestData as $manifestRecord) {
+            if (!array_key_exists('target', $manifestRecord)) {
+                return sprintf('Missing required key `target` in %s record', json_encode($manifestRecord));
+            }
+
+            if (!array_key_exists('value', $manifestRecord)) {
+                return sprintf('Missing required key `value` in %s record', json_encode($manifestRecord));
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ManifestGenerator/Validator/GlossaryKeyManifestValidatorStrategy.php
+++ b/src/ManifestGenerator/Validator/GlossaryKeyManifestValidatorStrategy.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\Validator;
+
+use SprykerSdk\Integrator\ManifestGenerator\GlossaryKeyManifestStrategy;
+
+class GlossaryKeyManifestValidatorStrategy implements ManifestValidatorStrategyInterface
+{
+    /**
+     * @param string $manifestKey
+     *
+     * @return bool
+     */
+    public function isApplicable(string $manifestKey): bool
+    {
+        return $manifestKey === GlossaryKeyManifestStrategy::MANIFEST_KEY;
+    }
+
+    /**
+     * @param array $manifestData
+     *
+     * @return string|null
+     */
+    public function validate(array $manifestData): ?string
+    {
+        if (!array_key_exists('new', $manifestData)) {
+            return sprintf('Missing required key `new` in %s record', json_encode($manifestData));
+        }
+
+        return null;
+    }
+}

--- a/src/ManifestGenerator/Validator/GlueRelationshipManifestValidatorStrategy.php
+++ b/src/ManifestGenerator/Validator/GlueRelationshipManifestValidatorStrategy.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\Validator;
+
+use SprykerSdk\Integrator\ManifestGenerator\GlueRelationshipManifestStrategy;
+
+class GlueRelationshipManifestValidatorStrategy implements ManifestValidatorStrategyInterface
+{
+    /**
+     * @param string $manifestKey
+     *
+     * @return bool
+     */
+    public function isApplicable(string $manifestKey): bool
+    {
+        return in_array($manifestKey, [
+            GlueRelationshipManifestStrategy::MANIFEST_KEY_WIRE,
+            GlueRelationshipManifestStrategy::MANIFEST_KEY_UNWIRE,
+        ], true);
+    }
+
+    /**
+     * @param array $manifestData
+     *
+     * @return string|null
+     */
+    public function validate(array $manifestData): ?string
+    {
+        foreach ($manifestData as $manifestRecord) {
+            if (!array_key_exists('source', $manifestRecord)) {
+                return sprintf('Missing required key `source` in %s record', json_encode($manifestRecord));
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ManifestGenerator/Validator/ManifestValidatorCollection.php
+++ b/src/ManifestGenerator/Validator/ManifestValidatorCollection.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\Validator;
+
+class ManifestValidatorCollection
+{
+    /**
+     * @var array<string>
+     */
+    protected const VALIDATORS = [
+        EnvConfigManifestValidatorStrategy::class,
+        GlueRelationshipManifestValidatorStrategy::class,
+        ModuleConfigManifestValidatorStrategy::class,
+        PluginsManifestValidatorStrategy::class,
+        WidgetManifestValidatorStrategy::class,
+        ArrayConfigElementManifestValidatorStrategy::class,
+        GlossaryKeyManifestValidatorStrategy::class,
+    ];
+
+    /**
+     * @var array<\SprykerSdk\Integrator\ManifestGenerator\Validator\ManifestValidatorStrategyInterface>
+     */
+    protected static $validatorsCache = [];
+
+    /**
+     * @param string $manifestKey
+     * @param array $manifestData
+     *
+     * @return string|null
+     */
+    public function validate(string $manifestKey, array $manifestData): ?string
+    {
+        $validators = $this->getValidators();
+
+        foreach ($validators as $validator) {
+            if (!$validator->isApplicable($manifestKey)) {
+                continue;
+            }
+
+            return $validator->validate($manifestData);
+        }
+
+        return sprintf('Manifest key `%s` is not supported', $manifestKey);
+    }
+
+    /**
+     * @return array<\SprykerSdk\Integrator\ManifestGenerator\Validator\ManifestValidatorStrategyInterface>
+     */
+    protected function getValidators(): array
+    {
+        if (static::$validatorsCache) {
+            return static::$validatorsCache;
+        }
+
+        foreach (static::VALIDATORS as $validatorClassName) {
+            static::$validatorsCache[] = new $validatorClassName();
+        }
+
+        return static::$validatorsCache;
+    }
+}

--- a/src/ManifestGenerator/Validator/ManifestValidatorStrategyInterface.php
+++ b/src/ManifestGenerator/Validator/ManifestValidatorStrategyInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\Validator;
+
+interface ManifestValidatorStrategyInterface
+{
+    /**
+     * @param string $manifestKey
+     *
+     * @return bool
+     */
+    public function isApplicable(string $manifestKey): bool;
+
+    /**
+     * @param array $manifestData
+     *
+     * @return string|null
+     */
+    public function validate(array $manifestData): ?string;
+}

--- a/src/ManifestGenerator/Validator/ModuleConfigManifestValidatorStrategy.php
+++ b/src/ManifestGenerator/Validator/ModuleConfigManifestValidatorStrategy.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\Validator;
+
+use SprykerSdk\Integrator\ManifestGenerator\ModuleConfigManifestStrategy;
+
+class ModuleConfigManifestValidatorStrategy implements ManifestValidatorStrategyInterface
+{
+    /**
+     * @param string $manifestKey
+     *
+     * @return bool
+     */
+    public function isApplicable(string $manifestKey): bool
+    {
+        return $manifestKey === ModuleConfigManifestStrategy::MANIFEST_KEY;
+    }
+
+    /**
+     * @param array $manifestData
+     *
+     * @return string|null
+     */
+    public function validate(array $manifestData): ?string
+    {
+        foreach ($manifestData as $manifestRecord) {
+            if (!array_key_exists('target', $manifestRecord)) {
+                return sprintf('Missing required key `target` in %s record', json_encode($manifestRecord));
+            }
+
+            if (!array_key_exists('value', $manifestRecord)) {
+                return sprintf('Missing required key `value` in %s record', json_encode($manifestRecord));
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ManifestGenerator/Validator/PluginsManifestValidatorStrategy.php
+++ b/src/ManifestGenerator/Validator/PluginsManifestValidatorStrategy.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\Validator;
+
+use SprykerSdk\Integrator\ManifestGenerator\PluginsManifestStrategy;
+
+class PluginsManifestValidatorStrategy implements ManifestValidatorStrategyInterface
+{
+    /**
+     * @param string $manifestKey
+     *
+     * @return bool
+     */
+    public function isApplicable(string $manifestKey): bool
+    {
+        return in_array($manifestKey, [
+            PluginsManifestStrategy::MANIFEST_KEY_WIRE,
+            PluginsManifestStrategy::MANIFEST_KEY_UNWIRE,
+        ], true);
+    }
+
+    /**
+     * @param array $manifestData
+     *
+     * @return string|null
+     */
+    public function validate(array $manifestData): ?string
+    {
+        foreach ($manifestData as $manifestRecord) {
+            if (!array_key_exists('target', $manifestRecord)) {
+                return sprintf('Missing required key `target` in %s record', json_encode($manifestRecord));
+            }
+
+            if (!array_key_exists('source', $manifestRecord)) {
+                return sprintf('Missing required key `source` in %s record', json_encode($manifestRecord));
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ManifestGenerator/Validator/WidgetManifestValidatorStrategy.php
+++ b/src/ManifestGenerator/Validator/WidgetManifestValidatorStrategy.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\Validator;
+
+use SprykerSdk\Integrator\ManifestGenerator\WidgetsManifestStrategy;
+
+class WidgetManifestValidatorStrategy implements ManifestValidatorStrategyInterface
+{
+    /**
+     * @param string $manifestKey
+     *
+     * @return bool
+     */
+    public function isApplicable(string $manifestKey): bool
+    {
+        return in_array($manifestKey, [
+            WidgetsManifestStrategy::MANIFEST_KEY_WIRE,
+            WidgetsManifestStrategy::MANIFEST_KEY_UNWIRE,
+        ], true);
+    }
+
+    /**
+     * @param array $manifestData
+     *
+     * @return string|null
+     */
+    public function validate(array $manifestData): ?string
+    {
+        foreach ($manifestData as $manifestRecord) {
+            if (!array_key_exists('source', $manifestRecord)) {
+                return sprintf('Missing required key `source` in %s record', json_encode($manifestRecord));
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ManifestGenerator/ValueExtractor/ArrayDimValueExtractor.php
+++ b/src/ManifestGenerator/ValueExtractor/ArrayDimValueExtractor.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ValueExtractor;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
+
+class ArrayDimValueExtractor implements ValueExtractorStrategyInterface
+{
+    /**
+     * @param \PhpParser\Node\Expr $expression
+     *
+     * @return bool
+     */
+    public function isApplicable(Expr $expression): bool
+    {
+        return $expression instanceof ArrayDimFetch;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\ArrayDimFetch $expression
+     * @param \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ValueExtractorStrategyCollection $valueExtractorStrategyCollection
+     *
+     * @return \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ExtractedValueObject
+     */
+    public function extractValue(Expr $expression, ValueExtractorStrategyCollection $valueExtractorStrategyCollection): ExtractedValueObject
+    {
+        /** @var \PhpParser\Node\Expr\Variable $variable */
+        $variable = $expression->var;
+        $varName = $variable->name;
+        $key = $valueExtractorStrategyCollection->execute($expression->dim);
+
+        return new ExtractedValueObject(sprintf('$%s[%s]', $varName, $key->getValue()), true);
+    }
+}

--- a/src/ManifestGenerator/ValueExtractor/ArrayValueExtractorStrategy.php
+++ b/src/ManifestGenerator/ValueExtractor/ArrayValueExtractorStrategy.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ValueExtractor;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Scalar\String_;
+
+class ArrayValueExtractorStrategy implements ValueExtractorStrategyInterface
+{
+    /**
+     * @param \PhpParser\Node\Expr $expression
+     *
+     * @return bool
+     */
+    public function isApplicable(Expr $expression): bool
+    {
+        return $expression instanceof Array_;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\Array_ $expression
+     * @param \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ValueExtractorStrategyCollection $valueExtractorStrategyCollection
+     *
+     * @return \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ExtractedValueObject
+     */
+    public function extractValue(Expr $expression, ValueExtractorStrategyCollection $valueExtractorStrategyCollection): ExtractedValueObject
+    {
+        $array = [];
+
+        foreach ($expression->items as $key => $item) {
+            $key = $item->key instanceof String_ ? $item->key->value : $key;
+            $array[$key] = $valueExtractorStrategyCollection->execute($item->value)->getValue();
+        }
+
+        return new ExtractedValueObject($array);
+    }
+}

--- a/src/ManifestGenerator/ValueExtractor/CastValueExtractor.php
+++ b/src/ManifestGenerator/ValueExtractor/CastValueExtractor.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ValueExtractor;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Cast;
+use PhpParser\Node\Expr\Cast\Array_;
+use PhpParser\Node\Expr\Cast\Bool_;
+use PhpParser\Node\Expr\Cast\Double;
+use PhpParser\Node\Expr\Cast\Int_;
+use PhpParser\Node\Expr\Cast\String_;
+
+class CastValueExtractor implements ValueExtractorStrategyInterface
+{
+    /**
+     * @param \PhpParser\Node\Expr $expression
+     *
+     * @return bool
+     */
+    public function isApplicable(Expr $expression): bool
+    {
+        return $expression instanceof Bool_
+            || $expression instanceof Int_
+            || $expression instanceof String_
+            || $expression instanceof Array_
+            || $expression instanceof Double;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\Cast $expression
+     * @param \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ValueExtractorStrategyCollection $valueExtractorStrategyCollection
+     *
+     * @return \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ExtractedValueObject
+     */
+    public function extractValue(Expr $expression, ValueExtractorStrategyCollection $valueExtractorStrategyCollection): ExtractedValueObject
+    {
+        $value = $valueExtractorStrategyCollection->execute($expression->expr);
+
+        return new ExtractedValueObject(
+            sprintf('(%s)%s', $this->generateTypeCastString($expression), $value->getValue()),
+            true,
+        );
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\Cast $castExpression
+     *
+     * @return string
+     */
+    protected function generateTypeCastString(Cast $castExpression): string
+    {
+        if ($castExpression instanceof Double) {
+            return 'float';
+        }
+
+        $className = get_class($castExpression);
+        $classNameParts = explode('\\', $className);
+
+        $classNamePart = end($classNameParts);
+
+        return str_replace('_', '', mb_strtolower($classNamePart));
+    }
+}

--- a/src/ManifestGenerator/ValueExtractor/ClassConstFetchValueExtractorStrategy.php
+++ b/src/ManifestGenerator/ValueExtractor/ClassConstFetchValueExtractorStrategy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ValueExtractor;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ClassConstFetch;
+
+class ClassConstFetchValueExtractorStrategy implements ValueExtractorStrategyInterface
+{
+    /**
+     * @param \PhpParser\Node\Expr $expression
+     *
+     * @return bool
+     */
+    public function isApplicable(Expr $expression): bool
+    {
+        return $expression instanceof ClassConstFetch;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\ClassConstFetch $expression
+     * @param \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ValueExtractorStrategyCollection $valueExtractorStrategyCollection
+     *
+     * @return \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ExtractedValueObject
+     */
+    public function extractValue(Expr $expression, ValueExtractorStrategyCollection $valueExtractorStrategyCollection): ExtractedValueObject
+    {
+        $prefix = strpos($expression->class->toString(), '\\') ? '\\' : '';
+
+        return new ExtractedValueObject(
+            sprintf('%s%s::%s', $prefix, $expression->class->toString(), $expression->name->toString()),
+        );
+    }
+}

--- a/src/ManifestGenerator/ValueExtractor/ConcatValueExtractorStrategy.php
+++ b/src/ManifestGenerator/ValueExtractor/ConcatValueExtractorStrategy.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ValueExtractor;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\Concat;
+
+class ConcatValueExtractorStrategy implements ValueExtractorStrategyInterface
+{
+    /**
+     * @param \PhpParser\Node\Expr $expression
+     *
+     * @return bool
+     */
+    public function isApplicable(Expr $expression): bool
+    {
+        return $expression instanceof Concat;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\BinaryOp\Concat $expression
+     * @param \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ValueExtractorStrategyCollection $valueExtractorStrategyCollection
+     *
+     * @return \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ExtractedValueObject
+     */
+    public function extractValue(Expr $expression, ValueExtractorStrategyCollection $valueExtractorStrategyCollection): ExtractedValueObject
+    {
+        $leftPart = $valueExtractorStrategyCollection->execute($expression->left)->getValue();
+        $rightPart = $valueExtractorStrategyCollection->execute($expression->right)->getValue();
+
+        return new ExtractedValueObject(
+            sprintf('%s . %s', $leftPart, $rightPart),
+            true,
+        );
+    }
+}

--- a/src/ManifestGenerator/ValueExtractor/ConstFetchValueExtractorStrategy.php
+++ b/src/ManifestGenerator/ValueExtractor/ConstFetchValueExtractorStrategy.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ValueExtractor;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ConstFetch;
+
+class ConstFetchValueExtractorStrategy implements ValueExtractorStrategyInterface
+{
+    /**
+     * @param \PhpParser\Node\Expr $expression
+     *
+     * @return bool
+     */
+    public function isApplicable(Expr $expression): bool
+    {
+        return $expression instanceof ConstFetch;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\ConstFetch $expression
+     * @param \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ValueExtractorStrategyCollection $valueExtractorStrategyCollection
+     *
+     * @return \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ExtractedValueObject
+     */
+    public function extractValue(Expr $expression, ValueExtractorStrategyCollection $valueExtractorStrategyCollection): ExtractedValueObject
+    {
+        return new ExtractedValueObject($this->filterValue($expression->name->toString()));
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return string|bool
+     */
+    protected function filterValue(string $value)
+    {
+        if ($value === 'true') {
+            return true;
+        }
+
+        if ($value === 'false') {
+            return false;
+        }
+
+        return $value;
+    }
+}

--- a/src/ManifestGenerator/ValueExtractor/ExtractedValueObject.php
+++ b/src/ManifestGenerator/ValueExtractor/ExtractedValueObject.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ValueExtractor;
+
+class ExtractedValueObject
+{
+    /**
+     * @var mixed
+     */
+    protected $value;
+
+    /**
+     * @var bool
+     */
+    protected bool $isLiteral = false;
+
+    /**
+     * @param mixed $value
+     * @param bool $isLiteral
+     */
+    public function __construct($value, bool $isLiteral = false)
+    {
+        $this->value = $value;
+        $this->isLiteral = $isLiteral;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isLiteral(): bool
+    {
+        return $this->isLiteral;
+    }
+}

--- a/src/ManifestGenerator/ValueExtractor/FloatValueExtractorStrategy.php
+++ b/src/ManifestGenerator/ValueExtractor/FloatValueExtractorStrategy.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ValueExtractor;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar\DNumber;
+
+class FloatValueExtractorStrategy implements ValueExtractorStrategyInterface
+{
+    /**
+     * @param \PhpParser\Node\Expr $expression
+     *
+     * @return bool
+     */
+    public function isApplicable(Expr $expression): bool
+    {
+        return $expression instanceof DNumber;
+    }
+
+    /**
+     * @param \PhpParser\Node\Scalar\DNumber $expression
+     * @param \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ValueExtractorStrategyCollection $valueExtractorStrategyCollection
+     *
+     * @return \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ExtractedValueObject
+     */
+    public function extractValue(Expr $expression, ValueExtractorStrategyCollection $valueExtractorStrategyCollection): ExtractedValueObject
+    {
+        return new ExtractedValueObject((float)$expression->value);
+    }
+}

--- a/src/ManifestGenerator/ValueExtractor/FuncCallValueExtractor.php
+++ b/src/ManifestGenerator/ValueExtractor/FuncCallValueExtractor.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ValueExtractor;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+
+class FuncCallValueExtractor implements ValueExtractorStrategyInterface
+{
+    /**
+     * @param \PhpParser\Node\Expr $expression
+     *
+     * @return bool
+     */
+    public function isApplicable(Expr $expression): bool
+    {
+        return $expression instanceof FuncCall;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\FuncCall $expression
+     * @param \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ValueExtractorStrategyCollection $valueExtractorStrategyCollection
+     *
+     * @return \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ExtractedValueObject
+     */
+    public function extractValue(Expr $expression, ValueExtractorStrategyCollection $valueExtractorStrategyCollection): ExtractedValueObject
+    {
+        $funcName = $expression->name->toString();
+
+        $args = [];
+        foreach ($expression->args as $arg) {
+            $args[] = var_export($valueExtractorStrategyCollection->execute($arg->value)->getValue(), true);
+        }
+
+        return new ExtractedValueObject(sprintf('%s(%s)', $funcName, implode(', ', $args)), true);
+    }
+}

--- a/src/ManifestGenerator/ValueExtractor/IntegerValueExtractorStrategy.php
+++ b/src/ManifestGenerator/ValueExtractor/IntegerValueExtractorStrategy.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ValueExtractor;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar\LNumber;
+
+class IntegerValueExtractorStrategy implements ValueExtractorStrategyInterface
+{
+    /**
+     * @param \PhpParser\Node\Expr $expression
+     *
+     * @return bool
+     */
+    public function isApplicable(Expr $expression): bool
+    {
+        return $expression instanceof LNumber;
+    }
+
+    /**
+     * @param \PhpParser\Node\Scalar\LNumber $expression
+     * @param \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ValueExtractorStrategyCollection $valueExtractorStrategyCollection
+     *
+     * @return \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ExtractedValueObject
+     */
+    public function extractValue(Expr $expression, ValueExtractorStrategyCollection $valueExtractorStrategyCollection): ExtractedValueObject
+    {
+        return new ExtractedValueObject((int)$expression->value);
+    }
+}

--- a/src/ManifestGenerator/ValueExtractor/StringValueExtractorStrategy.php
+++ b/src/ManifestGenerator/ValueExtractor/StringValueExtractorStrategy.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ValueExtractor;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar\String_;
+
+class StringValueExtractorStrategy implements ValueExtractorStrategyInterface
+{
+    /**
+     * @param \PhpParser\Node\Expr $expression
+     *
+     * @return bool
+     */
+    public function isApplicable(Expr $expression): bool
+    {
+        return $expression instanceof String_;
+    }
+
+    /**
+     * @param \PhpParser\Node\Scalar\String_ $expression
+     * @param \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ValueExtractorStrategyCollection $valueExtractorStrategyCollection
+     *
+     * @return \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ExtractedValueObject
+     */
+    public function extractValue(Expr $expression, ValueExtractorStrategyCollection $valueExtractorStrategyCollection): ExtractedValueObject
+    {
+        return new ExtractedValueObject((string)$expression->value);
+    }
+}

--- a/src/ManifestGenerator/ValueExtractor/ValueExtractorStrategyCollection.php
+++ b/src/ManifestGenerator/ValueExtractor/ValueExtractorStrategyCollection.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ValueExtractor;
+
+use SprykerSdk\Integrator\ManifestGenerator\Exception\ValueExtractorException;
+use PhpParser\Node\Expr;
+
+class ValueExtractorStrategyCollection
+{
+    /**
+     * @var array<string>
+     */
+    protected const STRATEGIES = [
+        ClassConstFetchValueExtractorStrategy::class,
+        ConstFetchValueExtractorStrategy::class,
+        FloatValueExtractorStrategy::class,
+        IntegerValueExtractorStrategy::class,
+        StringValueExtractorStrategy::class,
+        ConcatValueExtractorStrategy::class,
+        ArrayValueExtractorStrategy::class,
+        CastValueExtractor::class,
+        ArrayDimValueExtractor::class,
+        FuncCallValueExtractor::class,
+    ];
+
+    /**
+     * @var array<\SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ValueExtractorStrategyInterface>
+     */
+    protected $strategiesCache = [];
+
+    /**
+     * @param \PhpParser\Node\Expr $expression
+     *
+     * @throws \SprykerSdk\Integrator\ManifestGenerator\Exception\ValueExtractorException
+     *
+     * @return \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ExtractedValueObject
+     */
+    public function execute(Expr $expression): ExtractedValueObject
+    {
+        $strategies = $this->getStrategies();
+        foreach ($strategies as $strategy) {
+            if ($strategy->isApplicable($expression)) {
+                return $strategy->extractValue($expression, $this);
+            }
+        }
+
+        throw new ValueExtractorException(sprintf('%s expression type is not supported', get_class($expression)));
+    }
+
+    /**
+     * @return array<\SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ValueExtractorStrategyInterface>
+     */
+    protected function getStrategies(): array
+    {
+        if ($this->strategiesCache) {
+            return $this->strategiesCache;
+        }
+
+        foreach (static::STRATEGIES as $strategy) {
+            $this->strategiesCache[] = new $strategy();
+        }
+
+        return $this->strategiesCache;
+    }
+}

--- a/src/ManifestGenerator/ValueExtractor/ValueExtractorStrategyInterface.php
+++ b/src/ManifestGenerator/ValueExtractor/ValueExtractorStrategyInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator\ValueExtractor;
+
+use PhpParser\Node\Expr;
+
+interface ValueExtractorStrategyInterface
+{
+    /**
+     * @param \PhpParser\Node\Expr $expression
+     *
+     * @return bool
+     */
+    public function isApplicable(Expr $expression): bool;
+
+    /**
+     * @param \PhpParser\Node\Expr $expression
+     * @param \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ValueExtractorStrategyCollection $valueExtractorStrategyCollection
+     *
+     * @return \SprykerSdk\Integrator\ManifestGenerator\ValueExtractor\ExtractedValueObject
+     */
+    public function extractValue(Expr $expression, ValueExtractorStrategyCollection $valueExtractorStrategyCollection): ExtractedValueObject;
+}

--- a/src/ManifestGenerator/WidgetsManifestStrategy.php
+++ b/src/ManifestGenerator/WidgetsManifestStrategy.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace SprykerSdk\Integrator\ManifestGenerator;
+
+use SprykerSdk\Integrator\ManifestGenerator\Exception\SyntaxTreeException;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
+
+class WidgetsManifestStrategy extends AbstractManifestStrategy implements ManifestStrategyInterface
+{
+    /**
+     * @var string
+     */
+    public const MANIFEST_KEY_WIRE = 'wire-widget';
+
+    /**
+     * @var string
+     */
+    public const MANIFEST_KEY_UNWIRE = 'unwire-widget';
+
+    /**
+     * @var string
+     */
+    protected const WIDGET_METHOD_NAME = 'getGlobalWidgets';
+
+    /**
+     * @param string $fileName
+     *
+     * @return bool
+     */
+    public function isApplicable(string $fileName): bool
+    {
+        return strpos($fileName, 'ShopApplicationDependencyProvider.php') !== false;
+    }
+
+    /**
+     * @param string $fileName
+     * @param string $originalFileName
+     * @param array<string, array> $existingChanges
+     *
+     * @return array<string, array>
+     */
+    public function generateManifestData(string $fileName, string $originalFileName, array $existingChanges = []): array
+    {
+        $syntaxTree = $this->buildSyntaxTree($fileName);
+        $originalSyntaxTree = [];
+
+        if (file_exists($originalFileName)) {
+            $originalSyntaxTree = $this->buildSyntaxTree($originalFileName);
+        }
+
+        $data = $this->compareFiles($syntaxTree, $originalSyntaxTree);
+
+        return $this->buildManifestArray($data, $existingChanges);
+    }
+
+    /**
+     * @param array<\PhpParser\Node> $currentSyntaxTree
+     * @param array<\PhpParser\Node> $originalSyntaxTree
+     *
+     * @throws \SprykerSdk\Integrator\ManifestGenerator\Exception\SyntaxTreeException
+     *
+     * @return array<string, array>
+     */
+    protected function compareFiles(array $currentSyntaxTree, array $originalSyntaxTree): array
+    {
+        $originalRelationData = [];
+        if ($originalSyntaxTree) {
+            $originalMethod = $this->findClassMethod($originalSyntaxTree, static::WIDGET_METHOD_NAME);
+            if ($originalMethod) {
+                $originalRelationData = $this->extractWidgetList($originalMethod);
+            }
+        }
+
+        $currentMethod = $this->findClassMethod($currentSyntaxTree, static::WIDGET_METHOD_NAME);
+        if (!$currentMethod) {
+            throw new SyntaxTreeException(sprintf('Can\'t find a %s method in the ShopApplicationDependencyProvider', static::WIDGET_METHOD_NAME));
+        }
+        $currentRelationData = $this->extractWidgetList($currentMethod);
+
+        return [
+            static::WIRE => $this->gatherWidgets($currentRelationData, $originalRelationData),
+            static::UN_WIRE => $this->gatherWidgets($originalRelationData, $currentRelationData),
+        ];
+    }
+
+    /**
+     * @param array<string> $widgets
+     * @param array<string> $widgetsToCompare
+     *
+     * @return array<string>
+     */
+    protected function gatherWidgets(array $widgets, array $widgetsToCompare): array
+    {
+        return array_diff($widgets, $widgetsToCompare);
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\ClassMethod $classMethod
+     *
+     * @return array<string>
+     */
+    protected function extractWidgetList(ClassMethod $classMethod): array
+    {
+        $data = [];
+        if (!($classMethod->stmts[0] instanceof Return_) || (!$classMethod->stmts[0]->expr instanceof Array_)) {
+            return [];
+        }
+
+        foreach ($classMethod->stmts[0]->expr->items as $item) {
+            if ($item->value instanceof ClassConstFetch && $item->value->name->name === 'class') {
+                $data[] = '\\' . $item->value->class->toString();
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param array<string, array> $data
+     * @param array<string, array> $manifests
+     *
+     * @return array<string, array>
+     */
+    protected function buildManifestArray(array $data, array $manifests): array
+    {
+        foreach ($data as $type => $changes) {
+            foreach ($changes as $record) {
+                [$organization, $module] = $this->getOrganizationAndModuleName($record);
+                $manifestKey = $type === static::WIRE ? static::MANIFEST_KEY_WIRE : static::MANIFEST_KEY_UNWIRE;
+                $manifests[$organization . '.' . $module][$manifestKey][] = [
+                    static::SOURCE => $record,
+                ];
+            }
+        }
+
+        return $manifests;
+    }
+}

--- a/tests/SprykerSdkTest/Integrator/BaseTestCase.php
+++ b/tests/SprykerSdkTest/Integrator/BaseTestCase.php
@@ -10,7 +10,7 @@ namespace SprykerSdkTest\Integrator;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\CloningVisitor;
 use PhpParser\NodeVisitor\NameResolver;
-use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SprykerSdk\Integrator\IntegratorConfig;
@@ -19,7 +19,7 @@ use SprykerSdk\Integrator\Transfer\ClassInformationTransfer;
 use Symfony\Component\Filesystem\Filesystem;
 use ZipArchive;
 
-class BaseTestCase extends PHPUnitTestCase
+class BaseTestCase extends TestCase
 {
     use IntegratorFactoryAwareTrait;
 

--- a/tests/SprykerSdkTest/Integrator/ManifestGenerator/ArrayConfigElementManifestStrategyTest.php
+++ b/tests/SprykerSdkTest/Integrator/ManifestGenerator/ArrayConfigElementManifestStrategyTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SprykerSdkTest\Integrator\ManifestGenerator;
+
+use SprykerSdk\Integrator\ManifestGenerator\ArrayConfigElementManifestStrategy;
+use SprykerSdkTest\Integrator\BaseTestCase;
+
+class ArrayConfigElementManifestStrategyTest extends BaseTestCase
+{
+    /**
+     * @var string
+     */
+    protected const CURRENT_FILE_NAME = 'tests/_test_files/manifests/array_element/current/RabbitMqConfig.php';
+
+    /**
+     * @var string
+     */
+    protected const ORIGINAL_FILE_NAME = 'tests/_test_files/manifests/array_element/original/RabbitMqConfig.php';
+
+    /**
+     * @return void
+     */
+    public function testStrategy(): void
+    {
+        $pluginStrategy = new ArrayConfigElementManifestStrategy();
+        $result = [];
+
+        $result = $pluginStrategy->generateManifestData(static::CURRENT_FILE_NAME, static::ORIGINAL_FILE_NAME, $result);
+
+        $this->assertEquals([
+            'Spryker.TestIntegrator' => [
+                ArrayConfigElementManifestStrategy::MANIFEST_KEY => [
+                    [
+                        'target' => '\\Spryker\\Client\\RabbitMq\\RabbitMqConfig::getTestConfiguration',
+                        'value' => '\\Spryker\\Shared\\TestIntegrator\\TestIntegratorAddArrayElementFirst::TEST_INTEGRATION_ADD_ARRAY_ELEMENT_CONST_FIRST',
+                    ],
+                    [
+                        'target' => '\\Spryker\\Client\\RabbitMq\\RabbitMqConfig::getTestConfiguration',
+                        'value' => '\\Spryker\\Shared\\TestIntegrator\\TestIntegratorAddArrayElementSecond::TEST_INTEGRATION_ADD_ARRAY_ELEMENT_CONST_SECOND',
+                    ],
+                ],
+            ],
+        ], $result);
+    }
+}

--- a/tests/SprykerSdkTest/Integrator/ManifestGenerator/EnvConfigManifestStrategyTest.php
+++ b/tests/SprykerSdkTest/Integrator/ManifestGenerator/EnvConfigManifestStrategyTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace SprykerSdkTest\Integrator\ManifestGenerator;
+
+use SprykerSdk\Integrator\ManifestGenerator\EnvConfigManifestStrategy;
+use SprykerSdkTest\Integrator\BaseTestCase;
+
+class EnvConfigManifestStrategyTest extends BaseTestCase
+{
+    /**
+     * @var string
+     */
+    protected const CURRENT_FILE_NAME = 'tests/_test_files/manifests/dependency_provider/current/config.php';
+
+    /**
+     * @var string
+     */
+    protected const ORIGINAL_FILE_NAME = 'tests/_test_files/manifests/dependency_provider/original/config.php';
+
+    /**
+     * @return void
+     */
+    public function testStrategy(): void
+    {
+        $configStrategy = new EnvConfigManifestStrategy();
+        $result = [];
+
+        $result = $configStrategy->generateManifestData(static::CURRENT_FILE_NAME, static::ORIGINAL_FILE_NAME, $result);
+
+        $this->assertEquals([
+            'Spryker.Kernel' => [
+                'configure-env' => [
+                    [
+                        'target' => '\Spryker\Shared\Kernel\KernelConstants::RESOLVABLE_CLASS_NAMES_CACHE_ENABLED',
+                        'value' => true,
+                    ],
+                    [
+                        'target' => '\Spryker\Shared\Kernel\KernelConstants::PROJECT_NAMESPACE',
+                        'value' => 'Pyz',
+                    ],
+                    [
+                        'target' => '\Spryker\Shared\Kernel\KernelConstants::VAR_BOOL_CAST_VALUE',
+                        'value' => [
+                            'value' => '(bool)$config[\Spryker\Shared\Kernel\KernelConstants::PROJECT_NAMESPACE]',
+                            'is_literal' => true,
+                        ],
+                    ],
+                    [
+                        'target' => '\Spryker\Shared\Kernel\KernelConstants::FUNC_VALUE',
+                        'value' => [
+                            'value' => 'getenv(\'SOMEKEY\')',
+                            'is_literal' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ], $result);
+    }
+}

--- a/tests/SprykerSdkTest/Integrator/ManifestGenerator/GlossaryKeyManifestStrategyTest.php
+++ b/tests/SprykerSdkTest/Integrator/ManifestGenerator/GlossaryKeyManifestStrategyTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SprykerSdkTest\Integrator\ManifestGenerator;
+
+use SprykerSdk\Integrator\ManifestGenerator\GlossaryKeyManifestStrategy;
+use SprykerSdkTest\Integrator\BaseTestCase;
+
+class GlossaryKeyManifestStrategyTest extends BaseTestCase
+{
+    /**
+     * @var string
+     */
+    protected const CURRENT_FILE_NAME = 'tests/_test_files/manifests/glossary_key/current/glossary.csv';
+
+    /**
+     * @var string
+     */
+    protected const ORIGINAL_FILE_NAME = 'tests/_test_files/manifests/glossary_key/original/glossary.csv';
+
+    /**
+     * @return void
+     */
+    public function testStrategy(): void
+    {
+        $configStrategy = new GlossaryKeyManifestStrategy();
+        $result = [];
+
+        $result = $configStrategy->generateManifestData(static::CURRENT_FILE_NAME, static::ORIGINAL_FILE_NAME, $result);
+
+        $this->assertEquals([
+            '?.Cart' => [
+                'glossary-key' => [
+                    'new' => [
+                        'cart.shipping.order-item' => [
+                            'de_DE' => '+ Versand',
+                            'en_US' => '+ Shipping',
+                        ],
+                        'cart.shipping' => [
+                            'de_DE' => 'Versand',
+                            'en_US' => 'Shipping',
+                        ],
+                    ],
+                ],
+            ],
+        ], $result);
+    }
+}

--- a/tests/SprykerSdkTest/Integrator/ManifestGenerator/GlueRelationshipManifestStrategyTest.php
+++ b/tests/SprykerSdkTest/Integrator/ManifestGenerator/GlueRelationshipManifestStrategyTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SprykerSdkTest\Integrator\ManifestGenerator;
+
+use SprykerSdk\Integrator\ManifestGenerator\GlueRelationshipManifestStrategy;
+use SprykerSdkTest\Integrator\BaseTestCase;
+
+class GlueRelationshipManifestStrategyTest extends BaseTestCase
+{
+    /**
+     * @var string
+     */
+    protected const CURRENT_FILE_NAME = 'tests/_test_files/manifests/dependency_provider/current/GlueApplicationDependencyProvider.php';
+
+    /**
+     * @var string
+     */
+    protected const ORIGINAL_FILE_NAME = 'tests/_test_files/manifests/dependency_provider/original/GlueApplicationDependencyProvider.php';
+
+    /**
+     * @return void
+     */
+    public function testStrategy(): void
+    {
+        $glueRelationshipStrategy = new GlueRelationshipManifestStrategy();
+        $result = [];
+
+        $result = $glueRelationshipStrategy->generateManifestData(static::CURRENT_FILE_NAME, static::ORIGINAL_FILE_NAME, $result);
+
+        $this->assertEquals([
+            'Spryker.ProductsRestApi' => [
+                'wire-glue-relationship' => [
+                    [
+                        'source' => [
+                            '\Spryker\Glue\QuoteRequestsRestApi\QuoteRequestsRestApiConfig::RESOURCE_QUOTE_REQUESTS' => '\Spryker\Glue\ProductsRestApi\Plugin\GlueApplication\ConcreteProductByQuoteRequestResourceRelationshipPlugin',
+                        ],
+                    ],
+                ],
+            ],
+            'Spryker.CustomersRestApi' => [
+                'unwire-glue-relationship' => [
+                    [
+                        'source' => [
+                            '\Spryker\Glue\QuoteRequestsRestApi\QuoteRequestsRestApiConfig::RESOURCE_QUOTE_REQUESTS' => '\Spryker\Glue\CustomersRestApi\Plugin\GlueApplication\CustomerByQuoteRequestResourceRelationshipPlugin',
+                        ],
+                    ],
+                ],
+            ],
+        ], $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testStrategyWithNotExistedOriginalFle(): void
+    {
+        $glueRelationshipStrategy = new GlueRelationshipManifestStrategy();
+        $result = [];
+
+        $result = $glueRelationshipStrategy->generateManifestData(static::CURRENT_FILE_NAME, 'not_existed_file.php', $result);
+
+        $this->assertEquals([
+            'Spryker.ProductsRestApi' => [
+                'wire-glue-relationship' => [
+                    [
+                        'source' => [
+                            '\Spryker\Glue\QuoteRequestsRestApi\QuoteRequestsRestApiConfig::RESOURCE_QUOTE_REQUESTS' => '\Spryker\Glue\ProductsRestApi\Plugin\GlueApplication\ConcreteProductByQuoteRequestResourceRelationshipPlugin',
+                        ],
+                    ],
+                ],
+            ],
+        ], $result);
+    }
+}

--- a/tests/SprykerSdkTest/Integrator/ManifestGenerator/ModuleConfigManifestStrategyTest.php
+++ b/tests/SprykerSdkTest/Integrator/ManifestGenerator/ModuleConfigManifestStrategyTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace SprykerSdkTest\Integrator\ManifestGenerator;
+
+use SprykerSdk\Integrator\ManifestGenerator\ModuleConfigManifestStrategy;
+use SprykerSdkTest\Integrator\BaseTestCase;
+
+class ModuleConfigManifestStrategyTest extends BaseTestCase
+{
+    /**
+     * @var string
+     */
+    protected const CURRENT_FILE_NAME = 'tests/_test_files/manifests/dependency_provider/current/CartPageConfig.php';
+
+    /**
+     * @var string
+     */
+    protected const ORIGINAL_FILE_NAME = 'tests/_test_files/manifests/dependency_provider/original/CartPageConfig.php';
+
+    /**
+     * @return void
+     */
+    public function testStrategy(): void
+    {
+        $configStrategy = new ModuleConfigManifestStrategy();
+        $result = [];
+
+        $result = $configStrategy->generateManifestData(static::CURRENT_FILE_NAME, static::ORIGINAL_FILE_NAME, $result);
+
+        $this->assertEquals([
+            'SprykerShop.CartPage' => [
+                'configure-module' => [
+                    [
+                        'target' => '\SprykerShop\Yves\CartPage\CartPageConfig::getConfigMethod',
+                        'value' => '\SprykerShop\Yves\CartPage\CartPageConfig::SOME_VALUE',
+                    ],
+                    [
+                        'target' => '\SprykerShop\Yves\CartPage\CartPageConfig::ARRAY_VALUE',
+                        'value' => [
+                            10,
+                            1000,
+                        ],
+                    ],
+                    [
+                        'target' => '\SprykerShop\Yves\CartPage\CartPageConfig::ASSOC_ARRAY_VALUE',
+                        'value' => [
+                            'key_1' => 'key_1_value',
+                            'key_2' => 'key_2_value',
+                        ],
+                    ],
+                    [
+                        'target' => '\SprykerShop\Yves\CartPage\CartPageConfig::BOOL_VALUE',
+                        'value' => true,
+                    ],
+                ],
+            ],
+        ], $result);
+    }
+}

--- a/tests/SprykerSdkTest/Integrator/ManifestGenerator/PluginsManifestStrategyTest.php
+++ b/tests/SprykerSdkTest/Integrator/ManifestGenerator/PluginsManifestStrategyTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace SprykerSdkTest\Integrator\ManifestGenerator;
+
+use SprykerSdk\Integrator\ManifestGenerator\PluginsManifestStrategy;
+use SprykerSdkTest\Integrator\BaseTestCase;
+
+class PluginsManifestStrategyTest extends BaseTestCase
+{
+    /**
+     * @var string
+     */
+    protected const CURRENT_FILE_NAME = 'tests/_test_files/manifests/dependency_provider/current/ApplicationDependencyProvider.php';
+
+    /**
+     * @var string
+     */
+    protected const ORIGINAL_FILE_NAME = 'tests/_test_files/manifests/dependency_provider/original/ApplicationDependencyProvider.php';
+
+    /**
+     * @return void
+     */
+    public function testStrategy(): void
+    {
+        $pluginStrategy = new PluginsManifestStrategy();
+        $result = [];
+
+        $result = $pluginStrategy->generateManifestData(static::CURRENT_FILE_NAME, static::ORIGINAL_FILE_NAME, $result);
+
+        $this->assertEquals([
+            'Spryker.Session' => [
+                'wire-plugin' => [
+                    [
+                        'target' => '\Spryker\Zed\Application\ApplicationDependencyProvider::getBackofficeApplicationPlugins',
+                        'source' => '\Spryker\Zed\Session\Communication\Plugin\Application\SessionApplicationPlugin',
+                    ],
+                    [
+                        'target' => '\Spryker\Zed\Application\ApplicationDependencyProvider::getBackofficeApplicationPluginsWithRegularReturn',
+                        'source' => '\Spryker\Zed\Session\Communication\Plugin\Application\SessionApplicationPlugin',
+                    ],
+                ],
+            ],
+            'Spryker.EventDispatcher' => [
+                'unwire-plugin' => [
+                    [
+                        'target' => '\Spryker\Zed\Application\ApplicationDependencyProvider::getBackofficeApplicationPlugins',
+                        'source' => '\Spryker\Zed\EventDispatcher\Communication\Plugin\Application\EventDispatcherApplicationPlugin',
+                    ],
+                    [
+                        'target' => '\Spryker\Zed\Application\ApplicationDependencyProvider::getBackofficeApplicationPluginsWithRegularReturn',
+                        'source' => '\Spryker\Zed\EventDispatcher\Communication\Plugin\Application\EventDispatcherApplicationPlugin',
+                    ],
+                ],
+            ],
+        ], $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testStrategyWithNotExistingFile(): void
+    {
+        $pluginStrategy = new PluginsManifestStrategy();
+        $result = [];
+
+        $result = $pluginStrategy->generateManifestData(static::CURRENT_FILE_NAME, 'file_not_exists.php', $result);
+
+        $this->assertEquals([
+            'Spryker.Session' => [
+                'wire-plugin' => [
+                    [
+                        'target' => '\Spryker\Zed\Application\ApplicationDependencyProvider::getBackofficeApplicationPlugins',
+                        'source' => '\Spryker\Zed\Session\Communication\Plugin\Application\SessionApplicationPlugin',
+                    ],
+                    [
+                        'target' => '\Spryker\Zed\Application\ApplicationDependencyProvider::getBackofficeApplicationPluginsWithRegularReturn',
+                        'source' => '\Spryker\Zed\Session\Communication\Plugin\Application\SessionApplicationPlugin',
+                    ],
+                ],
+            ],
+        ], $result);
+    }
+}

--- a/tests/SprykerSdkTest/Integrator/ManifestGenerator/Validator/ArrayConfigElementManifestValidatorStrategyTest.php
+++ b/tests/SprykerSdkTest/Integrator/ManifestGenerator/Validator/ArrayConfigElementManifestValidatorStrategyTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace SprykerSdkTest\Integrator\ManifestGenerator\Validator;
+
+use SprykerSdk\Integrator\ManifestGenerator\ArrayConfigElementManifestStrategy;
+use SprykerSdk\Integrator\ManifestGenerator\Validator\ArrayConfigElementManifestValidatorStrategy;
+use SprykerSdk\Integrator\ManifestGenerator\Validator\ManifestValidatorStrategyInterface;
+use SprykerSdkTest\Integrator\BaseTestCase;
+
+class ArrayConfigElementManifestValidatorStrategyTest extends BaseTestCase
+{
+    /**
+     * @return void
+     */
+    public function testValidatorStrategy(): void
+    {
+        $validatorStrategy = $this->getValidatorStrategy();
+        $validationData = [
+            [
+                'target' => '\\Pyz\\Client\\RabbitMq\\RabbitMqConfig::getSynchronizationQueueConfiguration',
+                'value' => '\\Spryker\\Shared\\AssetExternalStorage\\AssetExternalStorageConfig::ASSET_EXTERNAL_SYNC_STORAGE_QUEUE',
+            ],
+        ];
+
+        $isApplicable = $validatorStrategy->isApplicable(ArrayConfigElementManifestStrategy::MANIFEST_KEY);
+        $validationResult = $validatorStrategy->validate($validationData);
+
+        $this->assertTrue($isApplicable);
+        $this->assertNull($validationResult);
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidationStrategyIsNotApplicable(): void
+    {
+        $validatorStrategy = $this->getValidatorStrategy();
+
+        $isApplicable = $validatorStrategy->isApplicable('wrong-key');
+
+        $this->assertFalse($isApplicable);
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidationStrategyReturnsError(): void
+    {
+        $validatorStrategy = $this->getValidatorStrategy();
+        $validationData = [
+            [
+                'target' => '\\Pyz\\Client\\RabbitMq\\RabbitMqConfig::getSynchronizationQueueConfiguration',
+            ],
+        ];
+
+        $validationResult = $validatorStrategy->validate($validationData);
+
+        $this->assertSame(
+            sprintf('Missing required key `value` in %s record', json_encode($validationData[0])),
+            $validationResult,
+        );
+    }
+
+    /**
+     * @return \App\Manifest\Validator\ManifestValidatorStrategyInterface
+     */
+    protected function getValidatorStrategy(): ManifestValidatorStrategyInterface
+    {
+        return new ArrayConfigElementManifestValidatorStrategy();
+    }
+}

--- a/tests/SprykerSdkTest/Integrator/ManifestGenerator/Validator/EnvConfigManifestValidatorStrategyTest.php
+++ b/tests/SprykerSdkTest/Integrator/ManifestGenerator/Validator/EnvConfigManifestValidatorStrategyTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SprykerSdkTest\Integrator\ManifestGenerator\Validator;
+
+use SprykerSdk\Integrator\ManifestGenerator\EnvConfigManifestStrategy;
+use SprykerSdk\Integrator\ManifestGenerator\Validator\EnvConfigManifestValidatorStrategy;
+use SprykerSdkTest\Integrator\BaseTestCase;
+
+class EnvConfigManifestValidatorStrategyTest extends BaseTestCase
+{
+    /**
+     * @return void
+     */
+    public function testValidatorStrategy(): void
+    {
+        $validatorStrategy = new EnvConfigManifestValidatorStrategy();
+        $validationData = [
+            [
+                'target' => '\Spryker\Shared\Kernel\KernelConstants::RESOLVABLE_CLASS_NAMES_CACHE_ENABLED',
+                'value' => true,
+            ],
+        ];
+
+        $isApplicable = $validatorStrategy->isApplicable(EnvConfigManifestStrategy::MANIFEST_KEY);
+        $validationResult = $validatorStrategy->validate($validationData);
+
+        $this->assertTrue($isApplicable);
+        $this->assertNull($validationResult);
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidationStrategyIsNotApplicable(): void
+    {
+        $validatorStrategy = new EnvConfigManifestValidatorStrategy();
+
+        $isApplicable = $validatorStrategy->isApplicable('wrong-key');
+
+        $this->assertFalse($isApplicable);
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidationStrategyReturnsError(): void
+    {
+        $validatorStrategy = new EnvConfigManifestValidatorStrategy();
+        $validationData = [
+            [
+                'target' => '\Spryker\Shared\Kernel\KernelConstants::RESOLVABLE_CLASS_NAMES_CACHE_ENABLED',
+            ],
+        ];
+
+        $validationResult = $validatorStrategy->validate($validationData);
+
+        $this->assertSame(
+            sprintf('Missing required key `value` in %s record', json_encode($validationData[0])),
+            $validationResult,
+        );
+    }
+}

--- a/tests/SprykerSdkTest/Integrator/ManifestGenerator/Validator/GlueRelationshipManifestValidatorStrategyTest.php
+++ b/tests/SprykerSdkTest/Integrator/ManifestGenerator/Validator/GlueRelationshipManifestValidatorStrategyTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SprykerSdkTest\Integrator\ManifestGenerator\Validator;
+
+use SprykerSdk\Integrator\ManifestGenerator\GlueRelationshipManifestStrategy;
+use SprykerSdk\Integrator\ManifestGenerator\Validator\GlueRelationshipManifestValidatorStrategy;
+use SprykerSdk\Integrator\ManifestGenerator\Validator\ManifestValidatorStrategyInterface;
+use SprykerSdkTest\Integrator\BaseTestCase;
+
+class GlueRelationshipManifestValidatorStrategyTest extends BaseTestCase
+{
+    /**
+     * @return void
+     */
+    public function testValidatorStrategy(): void
+    {
+        $validatorStrategy = $this->getValidatorStrategy();
+        $validationData = [
+            [
+                'source' => [
+                    '\Spryker\Glue\QuoteRequestsRestApi\QuoteRequestsRestApiConfig::RESOURCE_QUOTE_REQUESTS' => '\Spryker\Glue\ProductsRestApi\Plugin\GlueApplication\ConcreteProductByQuoteRequestResourceRelationshipPlugin',
+                ],
+            ],
+        ];
+
+        $isApplicable = $validatorStrategy->isApplicable(GlueRelationshipManifestStrategy::MANIFEST_KEY_WIRE);
+        $validationResult = $validatorStrategy->validate($validationData);
+
+        $this->assertTrue($isApplicable);
+        $this->assertNull($validationResult);
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidationStrategyIsNotApplicable(): void
+    {
+        $validatorStrategy = $this->getValidatorStrategy();
+
+        $isApplicable = $validatorStrategy->isApplicable('wrong-key');
+
+        $this->assertFalse($isApplicable);
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidationStrategyReturnsError(): void
+    {
+        $validatorStrategy = $this->getValidatorStrategy();
+        $validationData = [
+            [
+                [
+                    '\Spryker\Glue\QuoteRequestsRestApi\QuoteRequestsRestApiConfig::RESOURCE_QUOTE_REQUESTS' => '\Spryker\Glue\ProductsRestApi\Plugin\GlueApplication\ConcreteProductByQuoteRequestResourceRelationshipPlugin',
+                ],
+            ],
+        ];
+
+        $validationResult = $validatorStrategy->validate($validationData);
+
+        $this->assertSame(
+            sprintf('Missing required key `source` in %s record', json_encode($validationData[0])),
+            $validationResult,
+        );
+    }
+
+    /**
+     * @return \App\Manifest\Validator\ManifestValidatorStrategyInterface
+     */
+    protected function getValidatorStrategy(): ManifestValidatorStrategyInterface
+    {
+        return new GlueRelationshipManifestValidatorStrategy();
+    }
+}

--- a/tests/SprykerSdkTest/Integrator/ManifestGenerator/Validator/ModuleConfigManifestValidatorStrategyTest.php
+++ b/tests/SprykerSdkTest/Integrator/ManifestGenerator/Validator/ModuleConfigManifestValidatorStrategyTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace SprykerSdkTest\Integrator\ManifestGenerator\Validator;
+
+use SprykerSdk\Integrator\ManifestGenerator\ModuleConfigManifestStrategy;
+use SprykerSdk\Integrator\ManifestGenerator\Validator\ManifestValidatorStrategyInterface;
+use SprykerSdk\Integrator\ManifestGenerator\Validator\ModuleConfigManifestValidatorStrategy;
+use SprykerSdkTest\Integrator\BaseTestCase;
+
+class ModuleConfigManifestValidatorStrategyTest extends BaseTestCase
+{
+    /**
+     * @return void
+     */
+    public function testValidatorStrategy(): void
+    {
+        $validatorStrategy = $this->getValidatorStrategy();
+        $validationData = [
+            [
+                'target' => '\SprykerShop\Yves\CartPage\CartPageConfig::getConfigMethod',
+                'value' => '\SprykerShop\Yves\CartPage\CartPageConfig::SOME_VALUE',
+            ],
+        ];
+
+        $isApplicable = $validatorStrategy->isApplicable(ModuleConfigManifestStrategy::MANIFEST_KEY);
+        $validationResult = $validatorStrategy->validate($validationData);
+
+        $this->assertTrue($isApplicable);
+        $this->assertNull($validationResult);
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidationStrategyIsNotApplicable(): void
+    {
+        $validatorStrategy = $this->getValidatorStrategy();
+
+        $isApplicable = $validatorStrategy->isApplicable('wrong-key');
+
+        $this->assertFalse($isApplicable);
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidationStrategyReturnsError(): void
+    {
+        $validatorStrategy = $this->getValidatorStrategy();
+        $validationData = [
+            [
+                'target' => '\SprykerShop\Yves\CartPage\CartPageConfig::getConfigMethod',
+            ],
+        ];
+
+        $validationResult = $validatorStrategy->validate($validationData);
+
+        $this->assertSame(
+            sprintf('Missing required key `value` in %s record', json_encode($validationData[0])),
+            $validationResult,
+        );
+    }
+
+    /**
+     * @return \App\Manifest\Validator\ManifestValidatorStrategyInterface
+     */
+    protected function getValidatorStrategy(): ManifestValidatorStrategyInterface
+    {
+        return new ModuleConfigManifestValidatorStrategy();
+    }
+}

--- a/tests/SprykerSdkTest/Integrator/ManifestGenerator/Validator/PluginsManifestValidatorStrategyTest.php
+++ b/tests/SprykerSdkTest/Integrator/ManifestGenerator/Validator/PluginsManifestValidatorStrategyTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace SprykerSdkTest\Integrator\ManifestGenerator\Validator;
+
+use SprykerSdk\Integrator\ManifestGenerator\PluginsManifestStrategy;
+use SprykerSdk\Integrator\ManifestGenerator\Validator\ManifestValidatorStrategyInterface;
+use SprykerSdk\Integrator\ManifestGenerator\Validator\PluginsManifestValidatorStrategy;
+use SprykerSdkTest\Integrator\BaseTestCase;
+
+class PluginsManifestValidatorStrategyTest extends BaseTestCase
+{
+    /**
+     * @return void
+     */
+    public function testValidatorStrategy(): void
+    {
+        $validatorStrategy = $this->getValidatorStrategy();
+        $validationData = [
+            [
+                'target' => '\Spryker\Zed\Application\ApplicationDependencyProvider::getBackofficeApplicationPlugins',
+                'source' => '\Spryker\Zed\Session\Communication\Plugin\Application\SessionApplicationPlugin',
+            ],
+        ];
+
+        $isApplicable = $validatorStrategy->isApplicable(PluginsManifestStrategy::MANIFEST_KEY_WIRE);
+        $validationResult = $validatorStrategy->validate($validationData);
+
+        $this->assertTrue($isApplicable);
+        $this->assertNull($validationResult);
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidationStrategyIsNotApplicable(): void
+    {
+        $validatorStrategy = $this->getValidatorStrategy();
+
+        $isApplicable = $validatorStrategy->isApplicable('wrong-key');
+
+        $this->assertFalse($isApplicable);
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidationStrategyReturnsError(): void
+    {
+        $validatorStrategy = $this->getValidatorStrategy();
+        $validationData = [
+            [
+                'target' => '\Spryker\Zed\Application\ApplicationDependencyProvider::getBackofficeApplicationPlugins',
+            ],
+        ];
+
+        $validationResult = $validatorStrategy->validate($validationData);
+
+        $this->assertSame(
+            sprintf('Missing required key `source` in %s record', json_encode($validationData[0])),
+            $validationResult,
+        );
+    }
+
+    /**
+     * @return \App\Manifest\Validator\ManifestValidatorStrategyInterface
+     */
+    protected function getValidatorStrategy(): ManifestValidatorStrategyInterface
+    {
+        return new PluginsManifestValidatorStrategy();
+    }
+}

--- a/tests/SprykerSdkTest/Integrator/ManifestGenerator/Validator/WidgetManifestValidatorStrategyTest.php
+++ b/tests/SprykerSdkTest/Integrator/ManifestGenerator/Validator/WidgetManifestValidatorStrategyTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SprykerSdkTest\Integrator\ManifestGenerator\Validator;
+
+use SprykerSdk\Integrator\ManifestGenerator\Validator\ManifestValidatorStrategyInterface;
+use SprykerSdk\Integrator\ManifestGenerator\Validator\WidgetManifestValidatorStrategy;
+use SprykerSdk\Integrator\ManifestGenerator\WidgetsManifestStrategy;
+use SprykerSdkTest\Integrator\BaseTestCase;
+
+class WidgetManifestValidatorStrategyTest extends BaseTestCase
+{
+    /**
+     * @return void
+     */
+    public function testValidatorStrategy(): void
+    {
+        $validatorStrategy = $this->getValidatorStrategy();
+        $validationData = [
+            [
+                'source' => '\SprykerShop\Yves\MultiCartWidget\Widget\AddToMultiCartWidget',
+            ],
+        ];
+
+        $isApplicable = $validatorStrategy->isApplicable(WidgetsManifestStrategy::MANIFEST_KEY_WIRE);
+        $validationResult = $validatorStrategy->validate($validationData);
+
+        $this->assertTrue($isApplicable);
+        $this->assertNull($validationResult);
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidationStrategyIsNotApplicable(): void
+    {
+        $validatorStrategy = $this->getValidatorStrategy();
+
+        $isApplicable = $validatorStrategy->isApplicable('wrong-key');
+
+        $this->assertFalse($isApplicable);
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidationStrategyReturnsError(): void
+    {
+        $validatorStrategy = $this->getValidatorStrategy();
+        $validationData = [
+            [
+                '\SprykerShop\Yves\MultiCartWidget\Widget\AddToMultiCartWidget',
+            ],
+        ];
+
+        $validationResult = $validatorStrategy->validate($validationData);
+
+        $this->assertSame(
+            sprintf('Missing required key `source` in %s record', json_encode($validationData[0])),
+            $validationResult,
+        );
+    }
+
+    /**
+     * @return \App\Manifest\Validator\ManifestValidatorStrategyInterface
+     */
+    protected function getValidatorStrategy(): ManifestValidatorStrategyInterface
+    {
+        return new WidgetManifestValidatorStrategy();
+    }
+}

--- a/tests/SprykerSdkTest/Integrator/ManifestGenerator/WidgetManifestStrategyTest.php
+++ b/tests/SprykerSdkTest/Integrator/ManifestGenerator/WidgetManifestStrategyTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace SprykerSdkTest\Integrator\ManifestGenerator;
+
+use SprykerSdk\Integrator\ManifestGenerator\WidgetsManifestStrategy;
+use SprykerSdkTest\Integrator\BaseTestCase;
+
+class WidgetManifestStrategyTest extends BaseTestCase
+{
+    /**
+     * @var string
+     */
+    protected const CURRENT_FILE_NAME = 'tests/_test_files/manifests/dependency_provider/current/ShopApplicationDependencyProvider.php';
+
+    /**
+     * @var string
+     */
+    protected const ORIGINAL_FILE_NAME = 'tests/_test_files/manifests/dependency_provider/original/ShopApplicationDependencyProvider.php';
+
+    /**
+     * @return void
+     */
+    public function testStrategy(): void
+    {
+        $widgetStrategy = new WidgetsManifestStrategy();
+        $result = [];
+
+        $result = $widgetStrategy->generateManifestData(static::CURRENT_FILE_NAME, static::ORIGINAL_FILE_NAME, $result);
+
+        $this->assertEquals([
+            'SprykerShop.MultiCartWidget' => [
+                'wire-widget' => [
+                    [
+                        'source' => '\SprykerShop\Yves\MultiCartWidget\Widget\AddToMultiCartWidget',
+                    ],
+                ],
+            ],
+            'SprykerShop.ShoppingListWidget' => [
+                'unwire-widget' => [
+                    [
+                        'source' => '\SprykerShop\Yves\ShoppingListWidget\Widget\AddToShoppingListWidget',
+                    ],
+                ],
+            ],
+        ], $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testStrategyWithNotExistedOriginalFle(): void
+    {
+        $widgetStrategy = new WidgetsManifestStrategy();
+        $result = [];
+
+        $result = $widgetStrategy->generateManifestData(static::CURRENT_FILE_NAME, 'not_existed_file.php', $result);
+
+        $this->assertEquals([
+            'SprykerShop.MultiCartWidget' => [
+                'wire-widget' => [
+                    [
+                        'source' => '\SprykerShop\Yves\MultiCartWidget\Widget\AddToMultiCartWidget',
+                    ],
+                ],
+            ],
+        ], $result);
+    }
+}

--- a/tests/_tests_files/manifests/array_element/current/RabbitMqConfig.php
+++ b/tests/_tests_files/manifests/array_element/current/RabbitMqConfig.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the Spryker Suite.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Client\RabbitMq;
+
+use Spryker\Client\RabbitMq\RabbitMqConfig as SprykerRabbitMqConfig;
+use Spryker\Shared\TestIntegrator\TestIntegratorAddArrayElementExisted;
+use Spryker\Shared\TestIntegrator\TestIntegratorAddArrayElementFirst;
+use Spryker\Shared\TestIntegrator\TestIntegratorAddArrayElementSecond;
+
+class RabbitMqConfig extends SprykerRabbitMqConfig
+{
+    protected function getTestConfiguration(): array
+    {
+        return [
+            TestIntegratorAddArrayElementExisted::TEST_INTEGRATION_ADD_ARRAY_ELEMENT_CONST_EXISTED,
+            TestIntegratorAddArrayElementFirst::TEST_INTEGRATION_ADD_ARRAY_ELEMENT_CONST_FIRST,
+            TestIntegratorAddArrayElementSecond::TEST_INTEGRATION_ADD_ARRAY_ELEMENT_CONST_SECOND,
+        ];
+    }
+}

--- a/tests/_tests_files/manifests/array_element/original/RabbitMqConfig.php
+++ b/tests/_tests_files/manifests/array_element/original/RabbitMqConfig.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * This file is part of the Spryker Suite.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Client\RabbitMq;
+
+use Spryker\Client\RabbitMq\RabbitMqConfig as SprykerRabbitMqConfig;
+use Spryker\Shared\TestIntegrator\TestIntegratorAddArrayElementExisted;
+
+class RabbitMqConfig extends SprykerRabbitMqConfig
+{
+    protected function getTestConfiguration(): array
+    {
+        return [
+            TestIntegratorAddArrayElementExisted::TEST_INTEGRATION_ADD_ARRAY_ELEMENT_CONST_EXISTED,
+        ];
+    }
+}

--- a/tests/_tests_files/manifests/dependency_provider/ApplicationDependencyProvider.php
+++ b/tests/_tests_files/manifests/dependency_provider/ApplicationDependencyProvider.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of the Spryker Suite.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Zed\Application;
+
+use Spryker\Zed\Application\ApplicationDependencyProvider as SprykerApplicationDependencyProvider;
+use Spryker\Zed\ErrorHandler\Communication\Plugin\Application\ErrorHandlerApplicationPlugin;
+use Spryker\Zed\EventDispatcher\Communication\Plugin\Application\BackendApiEventDispatcherApplicationPlugin;
+use Spryker\Zed\EventDispatcher\Communication\Plugin\Application\BackendGatewayEventDispatcherApplicationPlugin;
+use Spryker\Zed\EventDispatcher\Communication\Plugin\Application\EventDispatcherApplicationPlugin;
+use Spryker\Zed\Form\Communication\Plugin\Application\FormApplicationPlugin;
+use Spryker\Zed\Http\Communication\Plugin\Application\HttpApplicationPlugin;
+use Spryker\Zed\Locale\Communication\Plugin\Application\LocaleApplicationPlugin;
+use Spryker\Zed\Messenger\Communication\Plugin\Application\MessengerApplicationPlugin;
+use Spryker\Zed\Propel\Communication\Plugin\Application\PropelApplicationPlugin;
+use Spryker\Zed\Router\Communication\Plugin\Application\BackendApiRouterApplicationPlugin;
+use Spryker\Zed\Router\Communication\Plugin\Application\BackendGatewayRouterApplicationPlugin;
+use Spryker\Zed\Router\Communication\Plugin\Application\BackofficeRouterApplicationPlugin;
+use Spryker\Zed\Security\Communication\Plugin\Application\SecurityApplicationPlugin;
+use Spryker\Zed\Session\Communication\Plugin\Application\MockArraySessionApplicationPlugin;
+use Spryker\Zed\Session\Communication\Plugin\Application\SessionApplicationPlugin;
+use Spryker\Zed\Translator\Communication\Plugin\Application\TranslatorApplicationPlugin;
+use Spryker\Zed\Twig\Communication\Plugin\Application\TwigApplicationPlugin;
+use Spryker\Zed\Validator\Communication\Plugin\Application\ValidatorApplicationPlugin;
+use Spryker\Zed\WebProfiler\Communication\Plugin\Application\WebProfilerApplicationPlugin;
+
+class ApplicationDependencyProvider extends SprykerApplicationDependencyProvider
+{
+    /**
+     * @return array<\Spryker\Shared\ApplicationExtension\Dependency\Plugin\ApplicationPluginInterface>
+     */
+    protected function getBackofficeApplicationPlugins(): array
+    {
+        $plugins = [
+            new SessionApplicationPlugin(),
+            new TwigApplicationPlugin(),
+            new EventDispatcherApplicationPlugin(),
+            new LocaleApplicationPlugin(),
+            new TranslatorApplicationPlugin(),
+            new MessengerApplicationPlugin(),
+            new PropelApplicationPlugin(),
+            new BackofficeRouterApplicationPlugin(),
+            new HttpApplicationPlugin(),
+            new ErrorHandlerApplicationPlugin(),
+            new FormApplicationPlugin(),
+            new ValidatorApplicationPlugin(),
+            new SecurityApplicationPlugin(),
+            new PropelApplicationPlugin(),
+        ];
+
+        return $plugins;
+    }
+}

--- a/tests/_tests_files/manifests/dependency_provider/current/ApplicationDependencyProvider.php
+++ b/tests/_tests_files/manifests/dependency_provider/current/ApplicationDependencyProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the Spryker Suite.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Zed\Application;
+
+use Spryker\Zed\Application\ApplicationDependencyProvider as SprykerApplicationDependencyProvider;
+use Spryker\Zed\Session\Communication\Plugin\Application\SessionApplicationPlugin;
+
+class ApplicationDependencyProvider extends SprykerApplicationDependencyProvider
+{
+    /**
+     * @return array<\Spryker\Shared\ApplicationExtension\Dependency\Plugin\ApplicationPluginInterface>
+     */
+    protected function getBackofficeApplicationPlugins(): array
+    {
+        $plugins = [
+            new SessionApplicationPlugin(),
+        ];
+
+        return $plugins;
+    }
+
+    /**
+     * @return array<\Spryker\Shared\ApplicationExtension\Dependency\Plugin\ApplicationPluginInterface>
+     */
+    protected function getBackofficeApplicationPluginsWithRegularReturn(): array
+    {
+        return [
+            new SessionApplicationPlugin(),
+        ];
+    }
+}

--- a/tests/_tests_files/manifests/dependency_provider/current/CartPageConfig.php
+++ b/tests/_tests_files/manifests/dependency_provider/current/CartPageConfig.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of the Spryker Suite.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Yves\CartPage;
+
+use SprykerShop\Yves\CartPage\CartPageConfig as SprykerCartPageConfig;
+
+class CartPageConfig extends SprykerCartPageConfig
+{
+    /**
+     * @var array<int>
+     */
+    protected const ARRAY_VALUE = [10, 1000];
+
+    /**
+     * @var array<string, string>
+     */
+    protected const ASSOC_ARRAY_VALUE = [
+        'key_1' => 'key_1_value',
+        'key_2' => 'key_2_value',
+    ];
+
+    /**
+     * @var bool
+     */
+    protected const BOOL_VALUE = true;
+
+    /**
+     * @return string
+     */
+    public function getConfigMethod(): string
+    {
+        return SprykerCartPageConfig::SOME_VALUE;
+    }
+}

--- a/tests/_tests_files/manifests/dependency_provider/current/GlueApplicationDependencyProvider.php
+++ b/tests/_tests_files/manifests/dependency_provider/current/GlueApplicationDependencyProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the Spryker Suite.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Glue\GlueApplication;
+
+use Spryker\Glue\ProductsRestApi\Plugin\GlueApplication\ConcreteProductByQuoteRequestResourceRelationshipPlugin;
+use Spryker\Glue\GlueApplication\GlueApplicationDependencyProvider as SprykerGlueApplicationDependencyProvider;
+use Spryker\Glue\GlueApplicationExtension\Dependency\Plugin\ResourceRelationshipCollectionInterface;
+use Spryker\Glue\QuoteRequestsRestApi\QuoteRequestsRestApiConfig;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+ */
+class GlueApplicationDependencyProvider extends SprykerGlueApplicationDependencyProvider
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @param \Spryker\Glue\GlueApplicationExtension\Dependency\Plugin\ResourceRelationshipCollectionInterface $resourceRelationshipCollection
+     *
+     * @return \Spryker\Glue\GlueApplicationExtension\Dependency\Plugin\ResourceRelationshipCollectionInterface
+     */
+    protected function getResourceRelationshipPlugins(
+        ResourceRelationshipCollectionInterface $resourceRelationshipCollection
+    ): ResourceRelationshipCollectionInterface {
+        $resourceRelationshipCollection->addRelationship(
+            QuoteRequestsRestApiConfig::RESOURCE_QUOTE_REQUESTS,
+            new ConcreteProductByQuoteRequestResourceRelationshipPlugin()
+        );
+
+        return $resourceRelationshipCollection;
+    }
+}

--- a/tests/_tests_files/manifests/dependency_provider/current/ShopApplicationDependencyProvider.php
+++ b/tests/_tests_files/manifests/dependency_provider/current/ShopApplicationDependencyProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the Spryker Suite.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Yves\ShopApplication;
+
+use SprykerShop\Yves\MultiCartWidget\Widget\AddToMultiCartWidget;
+use SprykerShop\Yves\ShopApplication\ShopApplicationDependencyProvider as SprykerShopApplicationDependencyProvider;
+
+/**
+ * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+ */
+class ShopApplicationDependencyProvider extends SprykerShopApplicationDependencyProvider
+{
+    /**
+     * @return array<string>
+     */
+    protected function getGlobalWidgets(): array
+    {
+        return [
+            AddToMultiCartWidget::class,
+        ];
+    }
+}

--- a/tests/_tests_files/manifests/dependency_provider/current/config.php
+++ b/tests/_tests_files/manifests/dependency_provider/current/config.php
@@ -1,0 +1,14 @@
+<?php
+
+use Spryker\Shared\Kernel\KernelConstants;
+
+$config[KernelConstants::RESOLVABLE_CLASS_NAMES_CACHE_ENABLED] = true;
+
+$config[KernelConstants::PROJECT_NAMESPACE]
+    = 'Pyz';
+
+$config[KernelConstants::VAR_BOOL_CAST_VALUE]
+    = (bool)$config[KernelConstants::PROJECT_NAMESPACE];
+
+$config[KernelConstants::FUNC_VALUE]
+    = getenv('SOMEKEY');

--- a/tests/_tests_files/manifests/dependency_provider/original/ApplicationDependencyProvider.php
+++ b/tests/_tests_files/manifests/dependency_provider/original/ApplicationDependencyProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the Spryker Suite.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Zed\Application;
+
+use Spryker\Zed\Application\ApplicationDependencyProvider as SprykerApplicationDependencyProvider;
+use Spryker\Zed\EventDispatcher\Communication\Plugin\Application\EventDispatcherApplicationPlugin;
+
+class ApplicationDependencyProvider extends SprykerApplicationDependencyProvider
+{
+    /**
+     * @return array<\Spryker\Shared\ApplicationExtension\Dependency\Plugin\ApplicationPluginInterface>
+     */
+    protected function getBackofficeApplicationPlugins(): array
+    {
+        $plugins = [
+            new EventDispatcherApplicationPlugin(),
+        ];
+
+        return $plugins;
+    }
+
+    /**
+     * @return array<\Spryker\Shared\ApplicationExtension\Dependency\Plugin\ApplicationPluginInterface>
+     */
+    protected function getBackofficeApplicationPluginsWithRegularReturn(): array
+    {
+        return [
+            new EventDispatcherApplicationPlugin(),
+        ];
+    }
+}

--- a/tests/_tests_files/manifests/dependency_provider/original/CartPageConfig.php
+++ b/tests/_tests_files/manifests/dependency_provider/original/CartPageConfig.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * This file is part of the Spryker Suite.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Yves\CartPage;
+
+use SprykerShop\Yves\CartPage\CartPageConfig as SprykerCartPageConfig;
+
+class CartPageConfig extends SprykerCartPageConfig
+{
+}

--- a/tests/_tests_files/manifests/dependency_provider/original/GlueApplicationDependencyProvider.php
+++ b/tests/_tests_files/manifests/dependency_provider/original/GlueApplicationDependencyProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the Spryker Suite.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Glue\GlueApplication;
+
+use Spryker\Glue\CustomersRestApi\Plugin\GlueApplication\CustomerByQuoteRequestResourceRelationshipPlugin;
+use Spryker\Glue\GlueApplication\GlueApplicationDependencyProvider as SprykerGlueApplicationDependencyProvider;
+use Spryker\Glue\GlueApplicationExtension\Dependency\Plugin\ResourceRelationshipCollectionInterface;
+use Spryker\Glue\QuoteRequestsRestApi\QuoteRequestsRestApiConfig;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+ */
+class GlueApplicationDependencyProvider extends SprykerGlueApplicationDependencyProvider
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @param \Spryker\Glue\GlueApplicationExtension\Dependency\Plugin\ResourceRelationshipCollectionInterface $resourceRelationshipCollection
+     *
+     * @return \Spryker\Glue\GlueApplicationExtension\Dependency\Plugin\ResourceRelationshipCollectionInterface
+     */
+    protected function getResourceRelationshipPlugins(
+        ResourceRelationshipCollectionInterface $resourceRelationshipCollection
+    ): ResourceRelationshipCollectionInterface {
+        $resourceRelationshipCollection->addRelationship(
+            QuoteRequestsRestApiConfig::RESOURCE_QUOTE_REQUESTS,
+            new CustomerByQuoteRequestResourceRelationshipPlugin()
+        );
+
+        return $resourceRelationshipCollection;
+    }
+}

--- a/tests/_tests_files/manifests/dependency_provider/original/ShopApplicationDependencyProvider.php
+++ b/tests/_tests_files/manifests/dependency_provider/original/ShopApplicationDependencyProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of the Spryker Suite.
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+
+namespace Pyz\Yves\ShopApplication;
+
+use SprykerShop\Yves\ShoppingListWidget\Widget\AddToShoppingListWidget;
+use SprykerShop\Yves\ShopApplication\ShopApplicationDependencyProvider as SprykerShopApplicationDependencyProvider;
+
+
+/**
+ * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+ */
+class ShopApplicationDependencyProvider extends SprykerShopApplicationDependencyProvider
+{
+    /**
+     * @return array<string>
+     */
+    protected function getGlobalWidgets(): array
+    {
+        return [
+            AddToShoppingListWidget::class,
+        ];
+    }
+}

--- a/tests/_tests_files/manifests/dependency_provider/original/config.php
+++ b/tests/_tests_files/manifests/dependency_provider/original/config.php
@@ -1,0 +1,6 @@
+<?php
+
+use Spryker\Shared\Kernel\KernelConstants;
+
+$config[KernelConstants::PROJECT_NAMESPACE]
+    = 'NotPyz';

--- a/tests/_tests_files/manifests/glossary_key/current/glossary.csv
+++ b/tests/_tests_files/manifests/glossary_key/current/glossary.csv
@@ -1,0 +1,17 @@
+key,translation,locale
+cart.remove.items.success,Produkte wurden erfolgreich aus dem Warenkorb entfernt,de_DE
+cart.remove.items.success,Products were removed successfully,en_US
+cart.add.items.success,Produkte erfolgreich im Warenkorb,de_DE
+cart.add.items.success,Items added successfully,en_US
+cart.your-order,Deine Bestellung,de_DE
+cart.your-order,Your Order,en_US
+cart.price,Preis,de_DE
+cart.price,Price,en_US
+cart.shipping.order-item,+ Versand,de_DE
+cart.shipping.order-item,+ Shipping,en_US
+cart.shipping,Versand,de_DE
+cart.shipping,Shipping,en_US
+cart.total,Gesamt,de_DE
+cart.total,Total,en_US
+cart.checkout,Zur Kasse,de_DE
+cart.checkout,Checkout,en_US

--- a/tests/_tests_files/manifests/glossary_key/original/glossary.csv
+++ b/tests/_tests_files/manifests/glossary_key/original/glossary.csv
@@ -1,0 +1,15 @@
+key,translation,locale
+cart.remove.items.success,Produkte wurden erfolgreich aus dem Warenkorb entfernt,de_DE
+cart.remove.items.success,Products were removed successfully,en_US
+cart.add.items.success,Produkte erfolgreich im Warenkorb,de_DE
+cart.add.items.success,Items added successfully,en_US
+cart.your-order,Deine Bestellung,de_DE
+cart.your-order,Your Order,en_US
+cart.price,Preis,de_DE
+cart.price,Price,en_US
+cart.shiping,Versand,de_DE
+cart.shiping,Shipping,en_US
+cart.total,Gesamt,de_DE
+cart.total,Total,en_US
+cart.checkout,Zur Kasse,de_DE
+cart.checkout,Checkout,en_US


### PR DESCRIPTION
WIP
This would move the code for generating manifests into the same repo as applying them

Pro:
- Easier to manage and test together

Con:
- No release app data scoped in (harder to detect what core module sth comes from without having that list of module changes)