### PR TITLE
Added support of the symfony 6.0 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
         "laminas/laminas-filter": "^2.11.0",
         "nikic/php-parser": "^4.3.0",
         "sebastian/diff": "^4.0.0",
-        "symfony/console": "^5.3.0",
-        "symfony/finder": "^5.3.0",
-        "symfony/process": "^5.4"
+        "symfony/console": "^5.3.0 || ^6.0",
+        "symfony/finder": "^5.3.0 || ^6.0",
+        "symfony/process": "^5.4 || ^6.0"
     },
     "require-dev": {
         "spryker/code-sniffer": "dev-master",
         "phpunit/phpunit": "^9.5.0",
         "phpstan/phpstan": "^1.0.0",
-        "symfony/filesystem": "^5.3.0"
+        "symfony/filesystem": "^5.3.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Ticket: https://spryker.atlassian.net/browse/SDK-1989
Long story short - because the integrator is used in two different applications - the release-app and the SDK, and each app has its own conflicting dependencies of Symfony packages integrator should be flexible.